### PR TITLE
[fix] cache endpoints properly on start

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,10 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## v0.14.0-1.11.2-adobe
+
+- fix issue where the endpoints were not cached properly on start
+
 ## v0.14.0-1.11.1-adobe
 
 - fix faulty `validIngressClass` function in upstream impl

--- a/cmd/contour/serve_adobe.go
+++ b/cmd/contour/serve_adobe.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func initCache(client *kubernetes.Clientset, contourClient *clientset.Clientset, reh *contour.ResourceEventHandler) error {
+func initCache(client *kubernetes.Clientset, contourClient *clientset.Clientset, reh *contour.ResourceEventHandler, et *contour.EndpointsTranslator) error {
 	reh.Info("starting cache initialization")
 
 	// Services
@@ -36,7 +36,7 @@ func initCache(client *kubernetes.Clientset, contourClient *clientset.Clientset,
 		return err
 	}
 	for i := range endpoints.Items {
-		reh.Insert(&endpoints.Items[i])
+		et.OnAdd(&endpoints.Items[i])
 	}
 	reh.WithField("count", len(endpoints.Items)).Info("endpoints")
 


### PR DESCRIPTION
- cache endpoints
- restore step ordering to the same as [upstream](https://github.com/heptio/contour/compare/release-0.14...lrouquette:bcook-v0.14-adobe-endpoints?expand=1#diff-9f9a13e8fc1e218a2563317b3a34d855) (reduce conflicts)