### PR TITLE
Prevent stacking LDS updates

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,9 +16,10 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
-## v0.15.0-1.12.1-adobe
+## v0.15.0-1.13.0-adobe
 
-- xDS version_info now a hash of the xDS response
+- xDS version_info now a hash of the xDS response + a timestamp
+- prevent stacking LDS updates
 
 ## v0.15.0-1.12.0-adobe
 

--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,10 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## v0.15.0-1.12.1-adobe
+
+- xDS version_info now a hash of the xDS response
+
 ## v0.15.0-1.12.0-adobe
 
 - built from contour v0.15.0

--- a/internal/contour/endpointstranslator.go
+++ b/internal/contour/endpointstranslator.go
@@ -165,6 +165,7 @@ func (e *EndpointsTranslator) recomputeClusterLoadAssignment(oldep, newep *v1.En
 				}
 				clas[portname] = cla
 			}
+			sort.Stable(endpointByIP(s.Addresses))
 			for _, a := range s.Addresses {
 				addr := envoy.SocketAddress(a.IP, int(p.Port))
 				cla.Endpoints[0].LbEndpoints = append(cla.Endpoints[0].LbEndpoints, envoy.LBEndpoint(addr))

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -330,6 +330,7 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 			for _, fc := range v.listeners[ENVOY_HTTPS_LISTENER].FilterChains {
 				if envoy.RetrieveSecretName(fc.TlsContext) == secretName {
 					fc.FilterChainMatch.ServerNames = append(fc.FilterChainMatch.ServerNames, vh.VirtualHost.Name)
+					sort.Strings(fc.FilterChainMatch.ServerNames)
 					fcExists = true
 					break
 				}
@@ -346,6 +347,7 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 			)
 
 			v.listeners[ENVOY_HTTPS_LISTENER].FilterChains = append(v.listeners[ENVOY_HTTPS_LISTENER].FilterChains, fc)
+			sort.Stable(filterChainTLSBySecretName(v.listeners[ENVOY_HTTPS_LISTENER].FilterChains))
 		}
 	default:
 		// recurse

--- a/internal/contour/sort_adobe.go
+++ b/internal/contour/sort_adobe.go
@@ -1,0 +1,23 @@
+// utility to sort various objects
+package contour
+
+import (
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	"github.com/heptio/contour/internal/envoy"
+	v1 "k8s.io/api/core/v1"
+)
+
+type endpointByIP []v1.EndpointAddress
+
+func (e endpointByIP) Len() int           { return len(e) }
+func (e endpointByIP) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
+func (e endpointByIP) Less(i, j int) bool { return e[i].IP < e[i].IP }
+
+// TLS-enabled, so assumes a secret is attached
+type filterChainTLSBySecretName []listener.FilterChain
+
+func (fc filterChainTLSBySecretName) Len() int      { return len(fc) }
+func (fc filterChainTLSBySecretName) Swap(i, j int) { fc[i], fc[j] = fc[j], fc[i] }
+func (fc filterChainTLSBySecretName) Less(i, j int) bool {
+	return envoy.RetrieveSecretName(fc[i].TlsContext) < envoy.RetrieveSecretName(fc[j].TlsContext)
+}

--- a/internal/grpc/xds.go
+++ b/internal/grpc/xds.go
@@ -186,15 +186,11 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 				// Since AfterFunc() is not perfectly accurate, we add 1s to now (we already waited 12min, so 1s is insignificant)
 				// This is to ensure we do send the update when the timer triggered
 				if earliestNextUpdate.After(now.Add(1 * time.Second)) {
-					fmt.Println("*** LDS NEED TO WAIT ***", last, earliestNextUpdate, now)
 					// Ok, we need to wait - check if the timer already started
 					if ldsTimer == nil {
-						fmt.Println("*** LDS -- CREATING TIMER ***")
 						waitDuration := time.Until(earliestNextUpdate)
 						manualTrigger := func() {
-							// Wait an extra 1s before triggering: AfterFunc() is not really accurate
-							fmt.Println("*** TIMER TRIGGERED ***", last)
-							ch <- last // TODO: figure out what to send here
+							ch <- last
 						}
 						ldsTimer = time.AfterFunc(waitDuration, manualTrigger)
 					}
@@ -202,7 +198,6 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 					goto WaitForChange
 				}
 				// Either the last response was sent long ago, or the timer triggered: reset it anyhow
-				fmt.Println("*** LDS: NO WAITING OR TIMER EXPIRED ***")
 				ldsTimer = nil
 			}
 

--- a/internal/grpc/xds.go
+++ b/internal/grpc/xds.go
@@ -17,12 +17,10 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
@@ -58,17 +56,6 @@ type grpcStream interface {
 	Send(*v2.DiscoveryResponse) error
 	Recv() (*v2.DiscoveryRequest, error)
 }
-
-// streamId uniquely identifies a stream
-type streamId struct {
-	TypeUrl string
-	NodeId  string
-}
-
-// A cache of data already sent, used for sending updates in an orderly manner
-// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#eventual-consistency-considerations
-var streamCache = make(map[streamId]map[string]string)
-var mutex = &sync.Mutex{}
 
 // stream processes a stream of DiscoveryRequests.
 func (xh *xdsHandler) stream(st grpcStream) (err error) {
@@ -299,129 +286,6 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 		case <-ctx.Done():
 			return ctx.Err()
 		}
-	}
-}
-
-// unsafe: assumes locking already in progress
-func isKnown(typeURL string, nodeId string, names []string) bool {
-	stId := streamId{
-		TypeUrl: typeURL,
-		NodeId:  nodeId,
-	}
-
-	switch typeURL {
-	case "type.googleapis.com/envoy.api.v2.Cluster":
-		// either the key (unique name) or the value (name known to EDS) will work
-		ret := true
-		for _, n := range names {
-			foundMatch := false
-			for k, v := range streamCache[stId] {
-				if n == k || n == v {
-					foundMatch = true
-					break
-				}
-			}
-			ret = ret && foundMatch
-			// no need to check other names if that one wasn't found
-			if !ret {
-				return ret
-			}
-		}
-		return ret
-	case "type.googleapis.com/envoy.api.v2.Listener":
-		ret := true
-		for _, n := range names {
-			_, ok := streamCache[stId][n]
-			ret = ret && ok
-		}
-		return ret
-	default:
-		fmt.Println("isKnown: unknown typeURL", typeURL)
-	}
-	return true
-}
-
-func diff(typeURL string, nodeId string, names []string) []string {
-	stId := streamId{
-		TypeUrl: typeURL,
-		NodeId:  nodeId,
-	}
-
-	switch typeURL {
-	case "type.googleapis.com/envoy.api.v2.Cluster":
-		// either the key (unique name) or the value (name known to EDS) will work
-		ret := make([]string, 0)
-		for _, n := range names {
-			foundMatch := false
-			for k, v := range streamCache[stId] {
-				if n == k || n == v {
-					foundMatch = true
-					break
-				}
-			}
-			if !foundMatch {
-				ret = append(ret, n)
-			}
-		}
-		return ret
-	default:
-		fmt.Println("diff: not implemented", typeURL)
-	}
-	return []string{}
-}
-
-func cacheData(stId streamId, data []proto.Message) {
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	// clear out CDS and LDS
-	if streamCache[stId] == nil ||
-		stId.TypeUrl == "type.googleapis.com/envoy.api.v2.Cluster" ||
-		stId.TypeUrl == "type.googleapis.com/envoy.api.v2.Listener" {
-		streamCache[stId] = make(map[string]string)
-	}
-
-	for _, r := range data {
-		switch v := r.(type) {
-		case *v2.Cluster:
-			// cluster-name: some unique name across the entire cluster
-			// https://github.com/envoyproxy/go-control-plane/blob/c7e2a120463a2209c6a0871d778f4eab96457e6b/envoy/api/v2/cds.pb.go#L323-L328
-			// service-name: the actual cluster name presented to EDS
-			// https://github.com/envoyproxy/go-control-plane/blob/c7e2a120463a2209c6a0871d778f4eab96457e6b/envoy/api/v2/cds.pb.go#L1047
-			//
-			// map[cluster-name] => service-name
-			streamCache[stId][v.Name] = v.GetEdsClusterConfig().GetServiceName()
-
-		case *v2.ClusterLoadAssignment:
-			nb := len(v.GetEndpoints())
-			current, _ := strconv.Atoi(streamCache[stId]["total"])
-			streamCache[stId]["total"] = strconv.Itoa(current + nb)
-
-		case *v2.Listener:
-			streamCache[stId][v.Name] = "known"
-
-		case *v2.RouteConfiguration:
-			// not caching routes for now
-
-		case *auth.Secret:
-			// not caching secrets for now
-
-		default:
-			// fmt.Println("no idea what to cache", v)
-		}
-	}
-}
-
-func lessProtoMessage(x, y proto.Message) bool {
-	switch xm := x.(type) {
-	case *v2.Cluster:
-		ym := y.(*v2.Cluster)
-		return xm.Name < ym.Name
-	case *v2.Listener:
-		ym := y.(*v2.Listener)
-		return xm.Name < ym.Name
-	default:
-		return true
 	}
 }
 

--- a/internal/grpc/xds_adobe.go
+++ b/internal/grpc/xds_adobe.go
@@ -4,12 +4,45 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 )
+
+var oldDate time.Time = time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC)
 
 func hash(data []proto.Message) string {
 	jsonBytes, _ := json.Marshal(data)
 	hash := md5.Sum(jsonBytes)
 	return hex.EncodeToString(hash[:])
+}
+
+// splitVersionInfo splits a xDS VersionInfo into a hash and timestamp.
+// The timestamp is the date when the xDS response was sent: if it cannot be parsed
+// or doesn't exist, it is set to an old date (1/1/2000)
+func splitVersionInfo(vinfo string) (string, time.Time) {
+	v := strings.Split(vinfo, ",")
+	switch len(v) {
+	case 0:
+		// First Envoy request
+		return "", oldDate
+	case 1:
+		// Just a version
+		return v[0], oldDate
+	default:
+		var t time.Time
+		i, err := strconv.ParseInt(v[1], 10, 64)
+		if err != nil {
+			t = oldDate
+		}
+		t = time.Unix(i, 0)
+		return v[0], t
+	}
+}
+
+// joinVersionInfo performs the opposite operation of splitVersionInfo.
+func joinVersionInfo(hash string, ts time.Time) string {
+	return strings.Join([]string{hash, strconv.FormatInt(ts.Unix(), 10)}, ",")
 }

--- a/internal/grpc/xds_adobe.go
+++ b/internal/grpc/xds_adobe.go
@@ -4,14 +4,153 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/gogo/protobuf/proto"
 )
 
+// streamId uniquely identifies a stream
+type streamId struct {
+	TypeUrl string
+	NodeId  string
+}
+
+// A cache of data already sent, used for sending updates in an orderly manner
+// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#eventual-consistency-considerations
+var streamCache = make(map[streamId]map[string]string)
+var mutex = &sync.Mutex{}
+
+// default date when none is used in the version
 var oldDate time.Time = time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC)
+
+// unsafe: assumes locking already in progress
+func isKnown(typeURL string, nodeId string, names []string) bool {
+	stId := streamId{
+		TypeUrl: typeURL,
+		NodeId:  nodeId,
+	}
+
+	switch typeURL {
+	case "type.googleapis.com/envoy.api.v2.Cluster":
+		// either the key (unique name) or the value (name known to EDS) will work
+		ret := true
+		for _, n := range names {
+			foundMatch := false
+			for k, v := range streamCache[stId] {
+				if n == k || n == v {
+					foundMatch = true
+					break
+				}
+			}
+			ret = ret && foundMatch
+			// no need to check other names if that one wasn't found
+			if !ret {
+				return ret
+			}
+		}
+		return ret
+	case "type.googleapis.com/envoy.api.v2.Listener":
+		ret := true
+		for _, n := range names {
+			_, ok := streamCache[stId][n]
+			ret = ret && ok
+		}
+		return ret
+	default:
+		fmt.Println("isKnown: unknown typeURL", typeURL)
+	}
+	return true
+}
+
+func diff(typeURL string, nodeId string, names []string) []string {
+	stId := streamId{
+		TypeUrl: typeURL,
+		NodeId:  nodeId,
+	}
+
+	switch typeURL {
+	case "type.googleapis.com/envoy.api.v2.Cluster":
+		// either the key (unique name) or the value (name known to EDS) will work
+		ret := make([]string, 0)
+		for _, n := range names {
+			foundMatch := false
+			for k, v := range streamCache[stId] {
+				if n == k || n == v {
+					foundMatch = true
+					break
+				}
+			}
+			if !foundMatch {
+				ret = append(ret, n)
+			}
+		}
+		return ret
+	default:
+		fmt.Println("diff: not implemented", typeURL)
+	}
+	return []string{}
+}
+
+func cacheData(stId streamId, data []proto.Message) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	// clear out CDS and LDS
+	if streamCache[stId] == nil ||
+		stId.TypeUrl == "type.googleapis.com/envoy.api.v2.Cluster" ||
+		stId.TypeUrl == "type.googleapis.com/envoy.api.v2.Listener" {
+		streamCache[stId] = make(map[string]string)
+	}
+
+	for _, r := range data {
+		switch v := r.(type) {
+		case *v2.Cluster:
+			// cluster-name: some unique name across the entire cluster
+			// https://github.com/envoyproxy/go-control-plane/blob/c7e2a120463a2209c6a0871d778f4eab96457e6b/envoy/api/v2/cds.pb.go#L323-L328
+			// service-name: the actual cluster name presented to EDS
+			// https://github.com/envoyproxy/go-control-plane/blob/c7e2a120463a2209c6a0871d778f4eab96457e6b/envoy/api/v2/cds.pb.go#L1047
+			//
+			// map[cluster-name] => service-name
+			streamCache[stId][v.Name] = v.GetEdsClusterConfig().GetServiceName()
+
+		case *v2.ClusterLoadAssignment:
+			nb := len(v.GetEndpoints())
+			current, _ := strconv.Atoi(streamCache[stId]["total"])
+			streamCache[stId]["total"] = strconv.Itoa(current + nb)
+
+		case *v2.Listener:
+			streamCache[stId][v.Name] = "known"
+
+		case *v2.RouteConfiguration:
+			// not caching routes for now
+
+		case *auth.Secret:
+			// not caching secrets for now
+
+		default:
+			// fmt.Println("no idea what to cache", v)
+		}
+	}
+}
+
+func lessProtoMessage(x, y proto.Message) bool {
+	switch xm := x.(type) {
+	case *v2.Cluster:
+		ym := y.(*v2.Cluster)
+		return xm.Name < ym.Name
+	case *v2.Listener:
+		ym := y.(*v2.Listener)
+		return xm.Name < ym.Name
+	default:
+		return true
+	}
+}
 
 func hash(data []proto.Message) string {
 	jsonBytes, _ := json.Marshal(data)

--- a/internal/grpc/xds_adobe.go
+++ b/internal/grpc/xds_adobe.go
@@ -1,0 +1,15 @@
+package grpc
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/gogo/protobuf/proto"
+)
+
+func hash(data []proto.Message) string {
+	jsonBytes, _ := json.Marshal(data)
+	hash := md5.Sum(jsonBytes)
+	return hex.EncodeToString(hash[:])
+}


### PR DESCRIPTION
- prevent stacking LDS updates
- xDS version_info now a hash of the xDS response + a timestamp (required additional ordering)
- moved adobe-specific code to `_adobe.go` files