### PR TITLE
Disable TLS v1.1

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,10 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## v0.15.0-2.0.0-adobe
+
+- disable TLS 1.1
+
 ## v0.15.0-1.14.1-adobe
 
 - add gRPC keepalives for Contour -> Envoy

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -769,8 +769,8 @@ func MinProtoVersion(version string) auth.TlsParameters_TlsProtocol {
 	case "1.2":
 		return auth.TlsParameters_TLSv1_2
 	default:
-		// any other value is interpreted as TLS/1.1
-		return auth.TlsParameters_TLSv1_1
+		// any other value is interpreted as TLS/1.2
+		return auth.TlsParameters_TLSv1_2
 	}
 }
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2004,7 +2004,7 @@ func TestDAGInsert(t *testing.T) {
 								},
 							},
 							Secret:          secret(sec1),
-							MinProtoVersion: auth.TlsParameters_TLSv1_1,
+							MinProtoVersion: auth.TlsParameters_TLSv1_2,
 						},
 					),
 				},
@@ -4252,7 +4252,7 @@ func securevirtualhost(name string, sec *v1.Secret, v ...Vertex) *SecureVirtualH
 			Name:   name,
 			routes: routes(v...),
 		},
-		MinProtoVersion: auth.TlsParameters_TLSv1_1,
+		MinProtoVersion: auth.TlsParameters_TLSv1_2,
 		Secret:          secret(sec),
 	}
 }


### PR DESCRIPTION
TLS 1.1 is on a deprecation path:

https://webkit.org/blog/8462/deprecation-of-legacy-tls-1-0-and-1-1-versions/
https://security.googleblog.com/2018/10/modernizing-transport-security.html
https://blog.mozilla.org/security/2018/10/15/removing-old-versions-of-tls/

This PR sets the default TLS version to 1.2 instead of 1.1.