### PR TITLE
PerFilterConfig now a first class type

### DIFF
--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -108,6 +108,27 @@ type HashPolicy struct {
 	Terminal bool `json:"terminal,omitempty"`
 }
 
+type PerFilterConfig struct {
+	IpAllowDeny *IpAllowDenyCidrs `json:"envoy.filters.http.ip_allow_deny,omitempty"`
+	HeaderSize  *HeaderSize       `json:"envoy.filters.http.header_size,omitempty"`
+}
+
+type IpAllowDenyCidrs struct {
+	AllowCidrs []Cidr `json:"allow_cidrs,omitempty"`
+	DenyCidrs  []Cidr `json:"deny_cidrs,omitempty"`
+}
+
+type Cidr struct {
+	AddressPrefix *string `json:"address_prefix,omitempty"`
+	PrefixLen     *int    `json:"prefix_len,omitempty"`
+}
+
+type HeaderSize struct {
+	HeaderSize struct {
+		MaxBytes *int `json:"max_bytes,omitempty"`
+	} `json:"header_size,omitempty"`
+}
+
 // Route contains the set of routes for a virtual host
 type Route struct {
 	// Match defines the prefix match
@@ -130,7 +151,7 @@ type Route struct {
 
 	HashPolicy []HashPolicy `json:"hashPolicy,omitempty"`
 
-	PerFilterConfig map[string]interface{} `json:"perFilterConfig,omitempty"`
+	PerFilterConfig *PerFilterConfig `json:"perFilterConfig,omitempty"`
 
 	Timeout *Duration `json:"timeout,omitempty"`
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -89,7 +89,7 @@ type Route struct {
 
 	HashPolicy []ingressroutev1.HashPolicy
 
-	PerFilterConfig map[string]interface{}
+	PerFilterConfig *ingressroutev1.PerFilterConfig
 
 	IdleTimeout *time.Duration
 }

--- a/internal/envoy/route_adobe.go
+++ b/internal/envoy/route_adobe.go
@@ -1,18 +1,24 @@
 package envoy
 
 import (
+	"encoding/json"
+
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 	"github.com/heptio/contour/internal/dag"
 )
 
 func PerFilterConfig(r *dag.Route) (conf map[string]*types.Struct) {
-	if len(r.PerFilterConfig) == 0 {
+	if r.PerFilterConfig == nil {
 		return
 	}
 
 	conf = make(map[string]*types.Struct)
-	for k, v := range r.PerFilterConfig {
+	var inInterface map[string]interface{}
+	inrec, _ := json.Marshal(r.PerFilterConfig)
+	json.Unmarshal(inrec, &inInterface)
+
+	for k, v := range inInterface {
 		s := new(types.Struct)
 		conf[k] = s
 

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/heptio/contour/internal/dag"
 	v1 "k8s.io/api/core/v1"
@@ -491,7 +492,6 @@ func TestUpgradeHTTPS(t *testing.T) {
 }
 
 func TestPerFilterConfig(t *testing.T) {
-	r := new(dag.Route)
 	msi := map[string]interface{}{
 		"filter": map[string]interface{}{
 			"map": map[string]interface{}{
@@ -503,8 +503,12 @@ func TestPerFilterConfig(t *testing.T) {
 			},
 		},
 	}
-	r.PerFilterConfig = msi
-	got := PerFilterConfig(r)
+	got := make(map[string]*types.Struct)
+	for k, v := range msi {
+		s := new(types.Struct)
+		got[k] = s
+		recurseIface(s, v)
+	}
 	want := map[string]*types.Struct{
 		"filter": {
 			Fields: map[string]*types.Value{


### PR DESCRIPTION
First stab at validating `PerFilterConfig`. For now, I removed the code that will set the IngressRoute Status as invalid, since this would be a breaking change (invalidating an existing ingressroute effectively removes it from envoy). 

I've added the PerFilterConfig spec to the CRD, which will do first-line validation.