### PR TITLE
Restoring unit-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ test: install
 test-race: | test
 	go test -race -mod=readonly $(MODULE)/...
 
+test-adobe:
+	CIDR_LIST_PATH= ZZZ_NO_SYNC_XDS=true go test -count=1 -mod=readonly $(MODULE)/...
+
 vet: | test
 	go vet $(MODULE)/...
 

--- a/adobe/adobe.go
+++ b/adobe/adobe.go
@@ -1,0 +1,56 @@
+package adobe
+
+import (
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ignore properties added/removed by our customization
+var ignoreProperties = []cmp.Option{
+	cmpopts.IgnoreFields(v2.Cluster{}, "CircuitBreakers", "DrainConnectionsOnHostRemoval"),
+	cmpopts.IgnoreFields(envoy_api_v2_core.HealthCheck_HttpHealthCheck{}, "ExpectedStatuses"),
+	cmpopts.IgnoreFields(envoy_api_v2_route.RouteAction{}, "RetryPolicy", "Timeout", "HashPolicy"),
+	cmpopts.IgnoreFields(envoy_api_v2_route.VirtualHost{}, "RetryPolicy"),
+}
+
+// list of tests to ignore (assuming names are unique across suites)
+var ignoreTests = map[string]struct{}{
+	"ingressroute root delegates to another ingressroute root":      {}, // root to root delegation
+	"root ingress delegating to another root w/ different hostname": {}, // root to root delegation
+	"self-edge produces a cycle":                                    {}, // root to root delegation
+	"multiple tls ingress with secrets should be sorted":            {}, // we group the filter chains together
+}
+
+func IgnoreFields() []cmp.Option {
+	return ignoreProperties
+}
+
+func ShouldSkipTest(name string) bool {
+	if _, ignore := ignoreTests[name]; ignore {
+		return true
+	}
+	return false
+}
+
+// Object resources
+func AdobefyObject(data interface{}) {
+	switch obj := data.(type) {
+	case *v1beta1.Ingress:
+		addClassAnnotation(&obj.ObjectMeta)
+	case *ingressroutev1.IngressRoute:
+		addClassAnnotation(&obj.ObjectMeta)
+	}
+}
+
+func addClassAnnotation(om *metav1.ObjectMeta) {
+	if metav1.HasAnnotation(*om, "kubernetes.io/ingress.class") {
+		return
+	}
+	metav1.SetMetaDataAnnotation(om, "kubernetes.io/ingress.class", "contour")
+}

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectcontour/contour/adobe"
+
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -855,7 +857,7 @@ func TestClusterVisit(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			root := buildDAG(tc.objs...)
 			got := visitClusters(root)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, adobe.IgnoreFields()...); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -16,6 +16,8 @@ package contour
 import (
 	"testing"
 
+	"github.com/projectcontour/contour/adobe"
+
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
@@ -270,7 +272,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
-					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:    envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG))),
 				}},
 			}),
@@ -357,13 +359,13 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"sortedfirst.example.com"},
 					},
-					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:    envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG))),
 				}, {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"sortedsecond.example.com"},
 					},
-					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:    envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG))),
 				}},
 			}),
@@ -479,7 +481,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
-					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:    envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG))),
 				}},
 				ListenerFilters: envoy.ListenerFilters(
@@ -560,7 +562,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
-					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:    envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG))),
 				}},
 				ListenerFilters: envoy.ListenerFilters(
@@ -634,7 +636,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
-					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:    envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG))),
 				}},
 			}),
@@ -706,7 +708,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
-					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:    envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG))),
 				}},
 			}),
@@ -775,7 +777,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
-					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TlsContext: tlscontext(envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:    envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy("/tmp/https_access.log"))),
 				}},
 			}),
@@ -993,6 +995,9 @@ func TestListenerVisit(t *testing.T) {
 	}
 
 	for name, tc := range tests {
+		if adobe.ShouldSkipTest(name) {
+			t.SkipNow()
+		}
 		t.Run(name, func(t *testing.T) {
 			root := buildDAG(tc.objs...)
 			got := visitListeners(root, &tc.ListenerVisitorConfig)

--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -16,6 +16,8 @@ package contour
 import (
 	"testing"
 
+	"github.com/projectcontour/contour/adobe"
+
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -537,6 +539,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 				},
 			}
 			for _, o := range tc.objs {
+				adobe.AdobefyObject(o)
 				builder.Source.Insert(o)
 			}
 			dag := builder.Build()

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -117,7 +117,7 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 				vh.Visit(func(v dag.Vertex) {
 					switch r := v.(type) {
 					case *dag.PrefixRoute:
-						rr := envoy.Route(envoy.RoutePrefix(r.Prefix), envoy.RouteRoute(&r.Route), &r.Route)
+						rr := envoy.RouteAdobe(envoy.RoutePrefix(r.Prefix), envoy.RouteRoute(&r.Route), &r.Route)
 
 						if r.HTTPSUpgrade {
 							rr.Action = envoy.UpgradeHTTPS()
@@ -125,7 +125,7 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 						}
 						routes = append(routes, rr)
 					case *dag.RegexRoute:
-						rr := envoy.Route(envoy.RouteRegex(r.Regex), envoy.RouteRoute(&r.Route), &r.Route)
+						rr := envoy.RouteAdobe(envoy.RouteRegex(r.Regex), envoy.RouteRoute(&r.Route), &r.Route)
 
 						if r.HTTPSUpgrade {
 							rr.Action = envoy.UpgradeHTTPS()
@@ -147,12 +147,12 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 					case *dag.PrefixRoute:
 						routes = append(
 							routes,
-							envoy.Route(envoy.RoutePrefix(r.Prefix), envoy.RouteRoute(&r.Route), &r.Route),
+							envoy.RouteAdobe(envoy.RoutePrefix(r.Prefix), envoy.RouteRoute(&r.Route), &r.Route),
 						)
 					case *dag.RegexRoute:
 						routes = append(
 							routes,
-							envoy.Route(envoy.RouteRegex(r.Regex), envoy.RouteRoute(&r.Route), &r.Route),
+							envoy.RouteAdobe(envoy.RouteRegex(r.Regex), envoy.RouteRoute(&r.Route), &r.Route),
 						)
 					}
 				})

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectcontour/contour/adobe"
+
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/golang/protobuf/proto"
@@ -1324,7 +1326,7 @@ func TestRouteVisit(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			root := buildDAG(tc.objs...)
 			got := visitRoutes(root)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, adobe.IgnoreFields()...); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/projectcontour/contour/adobe"
+
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/golang/protobuf/proto"
@@ -473,6 +475,7 @@ func TestSecretVisit(t *testing.T) {
 func buildDAG(objs ...interface{}) *dag.DAG {
 	var builder dag.Builder
 	for _, o := range objs {
+		adobe.AdobefyObject(o)
 		builder.Source.Insert(o)
 	}
 	return builder.Build()

--- a/internal/contour/visitor_test.go
+++ b/internal/contour/visitor_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectcontour/contour/adobe"
+
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -80,7 +82,7 @@ func TestVisitClusters(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := visitClusters(tc.root)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, adobe.IgnoreFields()...); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectcontour/contour/adobe"
+
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
@@ -2427,7 +2429,7 @@ func TestDAGInsert(t *testing.T) {
 								),
 							},
 							Secret:          secret(sec1),
-							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_2,
 						},
 					),
 				},
@@ -3554,7 +3556,7 @@ func TestDAGInsert(t *testing.T) {
 							VirtualHost: VirtualHost{
 								Name: "example.com",
 							},
-							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:          secret(sec1),
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(service(s9)),
@@ -3827,7 +3829,11 @@ func TestDAGInsert(t *testing.T) {
 					FieldLogger: testLogger(t),
 				},
 			}
+			if adobe.ShouldSkipTest(name) {
+				t.SkipNow()
+			}
 			for _, o := range tc.objs {
+				adobe.AdobefyObject(o)
 				if !builder.Source.Insert(o) {
 					t.Logf("insert %v: failed", o)
 				}
@@ -3847,6 +3853,7 @@ func TestDAGInsert(t *testing.T) {
 			opts := []cmp.Option{
 				cmp.AllowUnexported(VirtualHost{}),
 			}
+			opts = append(opts, adobe.IgnoreFields()...)
 			if diff := cmp.Diff(want, got, opts...); diff != "" {
 				t.Fatal(diff)
 			}
@@ -4147,6 +4154,7 @@ func TestDAGRootNamespaces(t *testing.T) {
 			}
 
 			for _, o := range tc.objs {
+				adobe.AdobefyObject(o)
 				builder.Source.Insert(o)
 			}
 			dag := builder.Build()
@@ -4505,7 +4513,7 @@ func securevirtualhost(name string, sec *v1.Secret, v ...Vertex) *SecureVirtualH
 			Name:   name,
 			routes: routes(v...),
 		},
-		MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+		MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_2,
 		Secret:          secret(sec),
 	}
 }

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -16,6 +16,8 @@ package dag
 import (
 	"testing"
 
+	"github.com/projectcontour/contour/adobe"
+
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/sirupsen/logrus"
@@ -817,9 +819,14 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			cache := KubernetesCache{
 				FieldLogger: testLogger(t),
 			}
+			if adobe.ShouldSkipTest(name) {
+				t.SkipNow()
+			}
 			for _, p := range tc.pre {
+				adobe.AdobefyObject(p)
 				cache.Insert(p)
 			}
+			adobe.AdobefyObject(tc.obj)
 			got := cache.Insert(tc.obj)
 			if tc.want != got {
 				t.Fatalf("Insert(%v): expected %v, got %v", tc.obj, tc.want, got)
@@ -834,6 +841,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			FieldLogger: testLogger(t),
 		}
 		for _, o := range objs {
+			adobe.AdobefyObject(o)
 			cache.Insert(o)
 		}
 		return &cache
@@ -993,6 +1001,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			adobe.AdobefyObject(tc.obj)
 			got := tc.cache.Remove(tc.obj)
 			if tc.want != got {
 				t.Fatalf("Remove(%v): expected %v, got %v", tc.obj, tc.want, got)

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -16,6 +16,8 @@ package dag
 import (
 	"testing"
 
+	"github.com/projectcontour/contour/adobe"
+
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -1041,7 +1043,11 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 					FieldLogger:    testLogger(t),
 				},
 			}
+			if adobe.ShouldSkipTest(name) {
+				t.SkipNow()
+			}
 			for _, o := range tc.objs {
+				adobe.AdobefyObject(o)
 				builder.Source.Insert(o)
 			}
 			dag := builder.Build()
@@ -1694,7 +1700,11 @@ func TestDAGHTTPProxyStatus(t *testing.T) {
 					FieldLogger:    testLogger(t),
 				},
 			}
+			if adobe.ShouldSkipTest(name) {
+				t.SkipNow()
+			}
 			for _, o := range tc.objs {
+				adobe.AdobefyObject(o)
 				builder.Source.Insert(o)
 			}
 

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectcontour/contour/adobe"
+
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	envoy "github.com/envoyproxy/go-control-plane/pkg/cache"
@@ -165,6 +167,7 @@ type resourceEventHandler struct {
 }
 
 func (r *resourceEventHandler) OnAdd(obj interface{}) {
+	adobe.AdobefyObject(obj)
 	switch obj.(type) {
 	case *v1.Endpoints:
 		r.EndpointsTranslator.OnAdd(obj)
@@ -175,6 +178,7 @@ func (r *resourceEventHandler) OnAdd(obj interface{}) {
 }
 
 func (r *resourceEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	adobe.AdobefyObject(newObj)
 	switch newObj.(type) {
 	case *v1.Endpoints:
 		r.EndpointsTranslator.OnUpdate(oldObj, newObj)
@@ -284,6 +288,8 @@ func (r *Response) Equals(want *v2.DiscoveryResponse) {
 }
 
 func assertEqual(t *testing.T, want, got *v2.DiscoveryResponse) {
+	// Modify with Adobe customizations
+	adobefyXDS(t, want)
 	t.Helper()
 	m := proto.TextMarshaler{Compact: true, ExpandAny: true}
 	a := m.Text(want)

--- a/internal/e2e/e2e_adobe.go
+++ b/internal/e2e/e2e_adobe.go
@@ -1,0 +1,125 @@
+package e2e
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
+	envoy_types "github.com/envoyproxy/go-control-plane/envoy/type"
+	envoy "github.com/envoyproxy/go-control-plane/pkg/cache"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/projectcontour/contour/internal/protobuf"
+)
+
+// CDS customization
+// add CircuitBreakers
+// set DrainConnectionsOnHostRemoval
+// cluster.IdleTimeout (TODO test)
+// add ExpectedStatuses
+var circuitBreakers = &envoy_cluster.CircuitBreakers{
+	Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{{
+		MaxConnections: protobuf.UInt32(1000000),
+		MaxRequests:    protobuf.UInt32(1000000),
+	}},
+}
+
+var expectedStatuses = []*envoy_types.Int64Range{
+	{
+		Start: 200,
+		End:   400,
+	},
+}
+
+// EDS customization
+// none
+
+// LDS customization
+// drop StatsListener
+// add envoy.listener.ip_allow_deny filter if CIDR_LIST_PATH is set (TODO test)
+
+// RDS customization
+// no default timeout, comes from ingressroute (removal done in rds_test.go/clustertimeout())
+// no default HashPolicy, comes from ingressroute (removal done in rds_test.go/withSessionAffinity())
+// no RetryPolicy (removal done in rds_test.go/routeretry())
+// ClassAnnotation - test skipped
+// root to root delegation - test skipped
+
+// SDS customization
+// none
+
+// adobefyXDS adds/drops Adobe customization to an xDS response object
+// this is intended to modify the "want" response in all the tests
+func adobefyXDS(t *testing.T, resp *v2.DiscoveryResponse) {
+	// First, un-marshall back to proto
+	rec := unResources(t, resp.Resources)
+
+	// xDS specific customization
+	switch resp.TypeUrl {
+	case envoy.ClusterType:
+		for _, c := range rec {
+			cluster := c.(*v2.Cluster)
+			cluster.CircuitBreakers = circuitBreakers
+			cluster.DrainConnectionsOnHostRemoval = true
+			if cluster.HealthChecks != nil {
+				for _, h := range cluster.HealthChecks {
+					h.GetHttpHealthCheck().ExpectedStatuses = expectedStatuses
+				}
+			}
+		}
+	case envoy.ListenerType:
+		// Find and remove the stats-listener
+		statsListenerIndex := -1
+		for i, l := range rec {
+			listener := l.(*v2.Listener)
+			if listener.Name == staticListener().Name {
+				statsListenerIndex = i
+			}
+		}
+		if statsListenerIndex != -1 {
+			// drop, but keep the order - no the best performing, but idiomatic
+			rec = append(rec[:statsListenerIndex], rec[statsListenerIndex+1:]...)
+		}
+	}
+
+	// Re-compute version info
+	resp.VersionInfo = hash(rec)
+
+	// Now, re-marshall
+	resp.Resources = resources(t, rec...)
+}
+
+// hash is the same one as internal/grpc/xds_adobe.go
+// except that an empty input is treated as nil
+// that's because resources() will return an empty array no matter what
+func hash(data []proto.Message) string {
+	if len(data) == 0 {
+		data = nil
+	}
+	jsonBytes, _ := json.Marshal(data)
+	hash := md5.Sum(jsonBytes)
+	return hex.EncodeToString(hash[:])
+}
+
+// unResources performs the opposite operation of resources().
+func unResources(t *testing.T, anys []*any.Any) []proto.Message {
+	t.Helper()
+	protos := make([]proto.Message, 0, len(anys))
+	for _, a := range anys {
+		protos = append(protos, toMessage(t, a))
+	}
+	return protos
+}
+
+// toMessage performs the opposite operation of toAny().
+func toMessage(t *testing.T, a *any.Any) proto.Message {
+	t.Helper()
+	var x ptypes.DynamicAny
+	err := ptypes.UnmarshalAny(a, &x)
+	check(t, err)
+	return x.Message
+}

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -401,7 +401,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		FilterChains: filterchaintls("kuard.example.com", secret1, envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout")), "h2", "http/1.1"),
 	}
 
-	l1.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = envoy_api_v2_auth.TlsParameters_TLSv1_1
+	l1.FilterChains[0].TlsContext.CommonTlsContext.TlsParams.TlsMinimumProtocolVersion = envoy_api_v2_auth.TlsParameters_TLSv1_2
 
 	// add service
 	rh.OnAdd(svc1)
@@ -1890,7 +1890,7 @@ func filterchaintls(domain string, secret *v1.Secret, filter *envoy_api_v2_liste
 			[]*envoy_api_v2_listener.Filter{
 				filter,
 			},
-			envoy_api_v2_auth.TlsParameters_TLSv1_1,
+			envoy_api_v2_auth.TlsParameters_TLSv1_2,
 			alpn...,
 		),
 	}

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectcontour/contour/adobe"
+
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -320,7 +322,7 @@ func TestCluster(t *testing.T) {
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
-				LbPolicy:       v2.Cluster_RING_HASH,
+				LbPolicy:       v2.Cluster_ROUND_ROBIN,
 				CommonLbConfig: ClusterCommonLBConfig(),
 			},
 		},
@@ -380,8 +382,8 @@ func TestCluster(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := Cluster(tc.cluster)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Fatal(diff)
+			if diff := cmp.Diff(tc.want, got, adobe.IgnoreFields()...); diff != "" {
+				t.Fatal(name, diff)
 			}
 		})
 	}
@@ -488,6 +490,8 @@ func TestClustername(t *testing.T) {
 }
 
 func TestLBPolicy(t *testing.T) {
+	// Adobe - renamed/customized policies - skip test
+	t.SkipNow()
 	tests := map[string]v2.Cluster_LbPolicy{
 		"WeightedLeastRequest": v2.Cluster_LEAST_REQUEST,
 		"Random":               v2.Cluster_RANDOM,

--- a/internal/envoy/healthcheck_test.go
+++ b/internal/envoy/healthcheck_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectcontour/contour/adobe"
+
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/google/go-cmp/cmp"
 	"github.com/projectcontour/contour/internal/dag"
@@ -95,7 +97,7 @@ func TestHealthCheck(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := healthCheck(tc.cluster)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, adobe.IgnoreFields()...); diff != "" {
 				t.Fatal(diff)
 			}
 

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -207,6 +207,8 @@ func TestDownstreamTLSContext(t *testing.T) {
 }
 
 func TestHTTPConnectionManager(t *testing.T) {
+	// Adobe - heavily customized - skipping
+	t.SkipNow()
 	tests := map[string]struct {
 		routename    string
 		accesslogger []*envoy_api_v2_accesslog.AccessLog

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -28,12 +28,11 @@ func Routes(routes ...*envoy_api_v2_route.Route) []*envoy_api_v2_route.Route {
 }
 
 // Route returns a *envoy_api_v2_route.Route for the supplied match and action.
-func Route(match *envoy_api_v2_route.RouteMatch, action *envoy_api_v2_route.Route_Route, r *dag.Route) *envoy_api_v2_route.Route {
+func Route(match *envoy_api_v2_route.RouteMatch, action *envoy_api_v2_route.Route_Route) *envoy_api_v2_route.Route {
 	return &envoy_api_v2_route.Route{
 		Match:               match,
 		Action:              action,
 		RequestHeadersToAdd: RouteHeaders(),
-		PerFilterConfig:     PerFilterConfig(r),
 	}
 }
 

--- a/internal/envoy/route_adobe.go
+++ b/internal/envoy/route_adobe.go
@@ -146,3 +146,14 @@ func setHashPolicy(r *dag.Route, ra *envoy_api_v2_route.RouteAction) {
 		}
 	}
 }
+
+// RouteAdobe: Route with Adobe customization
+func RouteAdobe(match *envoy_api_v2_route.RouteMatch, action *envoy_api_v2_route.Route_Route, route *dag.Route) *envoy_api_v2_route.Route {
+	// Call upstream Route so we can catch changes in the func signature!
+	ur := Route(match, action)
+
+	// Add customization here
+	ur.PerFilterConfig = PerFilterConfig(route)
+
+	return ur
+}

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectcontour/contour/adobe"
+
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	_struct "github.com/golang/protobuf/ptypes/struct"
 	"github.com/google/go-cmp/cmp"
@@ -50,11 +52,10 @@ func TestRoute(t *testing.T) {
 		},
 	}
 	match := RoutePrefix("/")
-	route := dag.Route{
+	action := RouteRoute(&dag.Route{
 		Clusters: []*dag.Cluster{cluster},
-	}
-	action := RouteRoute(&route)
-	got := Route(match, action, &route)
+	})
+	got := Route(match, action)
 	want := &envoy_api_v2_route.Route{
 		Match:               match,
 		Action:              action,
@@ -356,7 +357,7 @@ func TestRouteRoute(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := RouteRoute(tc.route)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, adobe.IgnoreFields()...); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -508,7 +509,7 @@ func TestVirtualHost(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := VirtualHost(tc.hostname)
-			if diff := cmp.Diff(got, tc.want); diff != "" {
+			if diff := cmp.Diff(got, tc.want, adobe.IgnoreFields()...); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/internal/featuretests/ingressclass_test.go
+++ b/internal/featuretests/ingressclass_test.go
@@ -33,6 +33,9 @@ func TestIngressClassAnnotation(t *testing.T) {
 	})
 	defer done()
 
+	// Adobe - we enforce an annotation: skip the entire suite
+	t.SkipNow()
+
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",

--- a/internal/grpc/xds.go
+++ b/internal/grpc/xds.go
@@ -17,11 +17,9 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"sync"
 	"sync/atomic"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/sirupsen/logrus"
@@ -55,17 +53,6 @@ type grpcStream interface {
 	Send(*envoy_api_v2.DiscoveryResponse) error
 	Recv() (*envoy_api_v2.DiscoveryRequest, error)
 }
-
-// streamId uniquely identifies a stream
-type streamId struct {
-	TypeUrl string
-	NodeId  string
-}
-
-// A cache of data already sent, used for sending updates in an orderly manner
-// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#eventual-consistency-considerations
-var streamCache = make(map[streamId]map[string]string)
-var mutex = &sync.Mutex{}
 
 // stream processes a stream of DiscoveryRequests.
 func (xh *xdsHandler) stream(st grpcStream) (err error) {
@@ -123,9 +110,13 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 		}
 		log = log.WithField("resource_names", req.ResourceNames).WithField("type_url", req.TypeUrl)
 
+		nodeID := "envoy-node"
+		if req.Node != nil {
+			nodeID = req.Node.Id
+		}
 		stId := streamId{
 			TypeUrl: req.TypeUrl,
-			NodeId:  req.Node.Id,
+			NodeId:  nodeID,
 		}
 
 	WaitForChange:
@@ -179,81 +170,7 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 			}
 
 			// Ensure we send this update in the right order
-			// "In order for EDS resources to be known or tracked by Envoy, there must exist an applied Cluster definition (e.g. sourced via CDS).
-			// A similar relationship exists between RDS and Listeners (e.g. sourced via LDS).""
-			// EDS will wait for CDS
-			// RDS will wait for LDS
-
-			freeToGo := false
-			for !freeToGo {
-				mutex.Lock()
-				switch req.TypeUrl {
-				case "type.googleapis.com/envoy.api.v2.Cluster":
-					freeToGo = true
-
-				case "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment":
-					// After CDS
-					if isKnown("type.googleapis.com/envoy.api.v2.Cluster", req.Node.Id, req.ResourceNames) {
-						freeToGo = true
-					}
-
-				case "type.googleapis.com/envoy.api.v2.Listener":
-					// After CDS and EDS
-					// FOR NOW: only ensure some CDS and EDS were sent (can't tie a listener back to a cluster or endpoint)
-					if len(streamCache[streamId{TypeUrl: "type.googleapis.com/envoy.api.v2.Cluster", NodeId: req.Node.Id}]) > 0 &&
-						len(streamCache[streamId{TypeUrl: "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment", NodeId: req.Node.Id}]) > 0 {
-						freeToGo = true
-					}
-
-				case "type.googleapis.com/envoy.api.v2.RouteConfiguration":
-					// After LDS and CDS
-					if isKnown("type.googleapis.com/envoy.api.v2.Listener", req.Node.Id, req.ResourceNames) {
-						// build a list of all the clusters referenced in this route config
-						clusterSet := make(map[string]struct{})
-						for _, rec := range resources {
-							rc := rec.(*envoy_api_v2.RouteConfiguration)
-							for _, v := range rc.GetVirtualHosts() {
-								for _, r := range v.GetRoutes() {
-									cl := r.GetRoute().GetCluster()
-									if cl != "" {
-										clusterSet[cl] = struct{}{}
-									}
-								}
-							}
-
-							// Convert the set of clusters to a slice
-							clusters := make([]string, 0, len(clusterSet))
-							for k := range clusterSet {
-								clusters = append(clusters, k)
-							}
-
-							// Ensure all these clusters were already sent
-							if isKnown("type.googleapis.com/envoy.api.v2.Cluster", req.Node.Id, clusters) {
-								freeToGo = true
-							} else {
-								unknown := diff("type.googleapis.com/envoy.api.v2.Cluster", req.Node.Id, clusters)
-								log.WithField("unknown", unknown).Info("wait_on_cds")
-							}
-							// TODO: also check route.GetVhds()
-						}
-						// } else {
-						//  TODO(lrouquet): log every 1s
-						// 	log.Info("wait_on_cds")
-					}
-
-				case "type.googleapis.com/envoy.api.v2.auth.Secret":
-					// uh? let's do after listener
-					if len(streamCache[streamId{TypeUrl: "type.googleapis.com/envoy.api.v2.Listener", NodeId: req.Node.Id}]) >= 2 {
-						freeToGo = true
-					}
-
-				default:
-					log.Warn("xDS response ordering: type not handled")
-					// might as well just send for now
-					freeToGo = true
-				}
-				mutex.Unlock()
-			}
+			synchronizeXDS(req, resources, log)
 
 			if err := st.Send(resp); err != nil {
 				return err
@@ -267,129 +184,6 @@ func (xh *xdsHandler) stream(st grpcStream) (err error) {
 		case <-ctx.Done():
 			return ctx.Err()
 		}
-	}
-}
-
-// unsafe: assumes locking already in progress
-func isKnown(typeURL string, nodeId string, names []string) bool {
-	stId := streamId{
-		TypeUrl: typeURL,
-		NodeId:  nodeId,
-	}
-
-	switch typeURL {
-	case "type.googleapis.com/envoy.api.v2.Cluster":
-		// either the key (unique name) or the value (name known to EDS) will work
-		ret := true
-		for _, n := range names {
-			foundMatch := false
-			for k, v := range streamCache[stId] {
-				if n == k || n == v {
-					foundMatch = true
-					break
-				}
-			}
-			ret = ret && foundMatch
-			// no need to check other names if that one wasn't found
-			if !ret {
-				return ret
-			}
-		}
-		return ret
-	case "type.googleapis.com/envoy.api.v2.Listener":
-		ret := true
-		for _, n := range names {
-			_, ok := streamCache[stId][n]
-			ret = ret && ok
-		}
-		return ret
-	default:
-		fmt.Println("isKnown: unknown typeURL", typeURL)
-	}
-	return true
-}
-
-func diff(typeURL string, nodeId string, names []string) []string {
-	stId := streamId{
-		TypeUrl: typeURL,
-		NodeId:  nodeId,
-	}
-
-	switch typeURL {
-	case "type.googleapis.com/envoy.api.v2.Cluster":
-		// either the key (unique name) or the value (name known to EDS) will work
-		ret := make([]string, 0)
-		for _, n := range names {
-			foundMatch := false
-			for k, v := range streamCache[stId] {
-				if n == k || n == v {
-					foundMatch = true
-					break
-				}
-			}
-			if !foundMatch {
-				ret = append(ret, n)
-			}
-		}
-		return ret
-	default:
-		fmt.Println("diff: not implemented", typeURL)
-	}
-	return []string{}
-}
-
-func cacheData(stId streamId, data []proto.Message) {
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	// clear out CDS and LDS
-	if streamCache[stId] == nil ||
-		stId.TypeUrl == "type.googleapis.com/envoy.api.v2.Cluster" ||
-		stId.TypeUrl == "type.googleapis.com/envoy.api.v2.Listener" {
-		streamCache[stId] = make(map[string]string)
-	}
-
-	for _, r := range data {
-		switch v := r.(type) {
-		case *envoy_api_v2.Cluster:
-			// cluster-name: some unique name across the entire cluster
-			// https://github.com/envoyproxy/go-control-plane/blob/c7e2a120463a2209c6a0871d778f4eab96457e6b/envoy/api/v2/cds.pb.go#L323-L328
-			// service-name: the actual cluster name presented to EDS
-			// https://github.com/envoyproxy/go-control-plane/blob/c7e2a120463a2209c6a0871d778f4eab96457e6b/envoy/api/v2/cds.pb.go#L1047
-			//
-			// map[cluster-name] => service-name
-			streamCache[stId][v.Name] = v.GetEdsClusterConfig().GetServiceName()
-
-		case *envoy_api_v2.ClusterLoadAssignment:
-			nb := len(v.GetEndpoints())
-			current, _ := strconv.Atoi(streamCache[stId]["total"])
-			streamCache[stId]["total"] = strconv.Itoa(current + nb)
-
-		case *envoy_api_v2.Listener:
-			streamCache[stId][v.Name] = "known"
-
-		case *envoy_api_v2.RouteConfiguration:
-			// not caching routes for now
-
-		case *envoy_api_v2_auth.Secret:
-			// not caching secrets for now
-
-		default:
-			// fmt.Println("no idea what to cache", v)
-		}
-	}
-}
-
-func lessProtoMessage(x, y proto.Message) bool {
-	switch xm := x.(type) {
-	case *envoy_api_v2.Cluster:
-		ym := y.(*envoy_api_v2.Cluster)
-		return xm.Name < ym.Name
-	case *envoy_api_v2.Listener:
-		ym := y.(*envoy_api_v2.Listener)
-		return xm.Name < ym.Name
-	default:
-		return true
 	}
 }
 

--- a/internal/grpc/xds_adobe.go
+++ b/internal/grpc/xds_adobe.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"sync"
 
@@ -31,6 +32,9 @@ var mutex = &sync.Mutex{}
 // EDS will wait for CDS
 // RDS will wait for LDS
 func synchronizeXDS(req *envoy_api_v2.DiscoveryRequest, resources []proto.Message, log *logrus.Entry) {
+	if _, ok := os.LookupEnv("ZZZ_NO_SYNC_XDS"); ok {
+		return
+	}
 	freeToGo := false
 	for !freeToGo {
 		mutex.Lock()

--- a/internal/grpc/xds_adobe.go
+++ b/internal/grpc/xds_adobe.go
@@ -4,9 +4,227 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"strconv"
+	"sync"
 
+	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoy "github.com/envoyproxy/go-control-plane/pkg/cache"
 	"github.com/golang/protobuf/proto"
+	"github.com/sirupsen/logrus"
 )
+
+// streamId uniquely identifies a stream
+type streamId struct {
+	TypeUrl string
+	NodeId  string
+}
+
+// A cache of data already sent, used for sending updates in an orderly manner
+// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#eventual-consistency-considerations
+var streamCache = make(map[streamId]map[string]string)
+var mutex = &sync.Mutex{}
+
+// "In order for EDS resources to be known or tracked by Envoy, there must exist an applied Cluster definition (e.g. sourced via CDS).
+// A similar relationship exists between RDS and Listeners (e.g. sourced via LDS).""
+// EDS will wait for CDS
+// RDS will wait for LDS
+func synchronizeXDS(req *envoy_api_v2.DiscoveryRequest, resources []proto.Message, log *logrus.Entry) {
+	freeToGo := false
+	for !freeToGo {
+		mutex.Lock()
+		switch req.TypeUrl {
+		case envoy.ClusterType:
+			freeToGo = true
+
+		case envoy.EndpointType:
+			// After CDS
+			if isKnown(envoy.ClusterType, req.Node.Id, req.ResourceNames) {
+				freeToGo = true
+			}
+
+		case envoy.ListenerType:
+			// After CDS and EDS
+			// FOR NOW: only ensure some CDS and EDS were sent (can't tie a listener back to a cluster or endpoint)
+			if len(streamCache[streamId{TypeUrl: envoy.ClusterType, NodeId: req.Node.Id}]) > 0 &&
+				len(streamCache[streamId{TypeUrl: envoy.EndpointType, NodeId: req.Node.Id}]) > 0 {
+				freeToGo = true
+			}
+
+		case envoy.RouteType:
+			// After LDS and CDS
+			if isKnown(envoy.ListenerType, req.Node.Id, req.ResourceNames) {
+				// build a list of all the clusters referenced in this route config
+				clusterSet := make(map[string]struct{})
+				for _, rec := range resources {
+					rc := rec.(*envoy_api_v2.RouteConfiguration)
+					for _, v := range rc.GetVirtualHosts() {
+						for _, r := range v.GetRoutes() {
+							cl := r.GetRoute().GetCluster()
+							if cl != "" {
+								clusterSet[cl] = struct{}{}
+							}
+						}
+					}
+
+					// Convert the set of clusters to a slice
+					clusters := make([]string, 0, len(clusterSet))
+					for k := range clusterSet {
+						clusters = append(clusters, k)
+					}
+
+					// Ensure all these clusters were already sent
+					if isKnown(envoy.ClusterType, req.Node.Id, clusters) {
+						freeToGo = true
+					} else {
+						unknown := diff(envoy.ClusterType, req.Node.Id, clusters)
+						log.WithField("unknown", unknown).Info("wait_on_cds")
+					}
+					// TODO: also check route.GetVhds()
+				}
+				// } else {
+				//  TODO(lrouquet): log every 1s
+				// 	log.Info("wait_on_cds")
+			}
+
+		case envoy.SecretType:
+			// uh? let's do after listener
+			if len(streamCache[streamId{TypeUrl: envoy.ListenerType, NodeId: req.Node.Id}]) >= 2 {
+				freeToGo = true
+			}
+
+		default:
+			log.Warn("xDS response ordering: type not handled")
+			// might as well just send for now
+			freeToGo = true
+		}
+		mutex.Unlock()
+	}
+}
+
+// unsafe: assumes locking already in progress
+func isKnown(typeURL string, nodeId string, names []string) bool {
+	stId := streamId{
+		TypeUrl: typeURL,
+		NodeId:  nodeId,
+	}
+
+	switch typeURL {
+	case envoy.ClusterType:
+		// either the key (unique name) or the value (name known to EDS) will work
+		ret := true
+		for _, n := range names {
+			foundMatch := false
+			for k, v := range streamCache[stId] {
+				if n == k || n == v {
+					foundMatch = true
+					break
+				}
+			}
+			ret = ret && foundMatch
+			// no need to check other names if that one wasn't found
+			if !ret {
+				return ret
+			}
+		}
+		return ret
+	case envoy.ListenerType:
+		ret := true
+		for _, n := range names {
+			_, ok := streamCache[stId][n]
+			ret = ret && ok
+		}
+		return ret
+	default:
+		fmt.Println("isKnown: unknown typeURL", typeURL)
+	}
+	return true
+}
+
+func diff(typeURL string, nodeId string, names []string) []string {
+	stId := streamId{
+		TypeUrl: typeURL,
+		NodeId:  nodeId,
+	}
+
+	switch typeURL {
+	case envoy.ClusterType:
+		// either the key (unique name) or the value (name known to EDS) will work
+		ret := make([]string, 0)
+		for _, n := range names {
+			foundMatch := false
+			for k, v := range streamCache[stId] {
+				if n == k || n == v {
+					foundMatch = true
+					break
+				}
+			}
+			if !foundMatch {
+				ret = append(ret, n)
+			}
+		}
+		return ret
+	default:
+		fmt.Println("diff: not implemented", typeURL)
+	}
+	return []string{}
+}
+
+func cacheData(stId streamId, data []proto.Message) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	// clear out CDS and LDS
+	if streamCache[stId] == nil ||
+		stId.TypeUrl == envoy.ClusterType ||
+		stId.TypeUrl == envoy.ListenerType {
+		streamCache[stId] = make(map[string]string)
+	}
+
+	for _, r := range data {
+		switch v := r.(type) {
+		case *envoy_api_v2.Cluster:
+			// cluster-name: some unique name across the entire cluster
+			// https://github.com/envoyproxy/go-control-plane/blob/c7e2a120463a2209c6a0871d778f4eab96457e6b/envoy/api/v2/cds.pb.go#L323-L328
+			// service-name: the actual cluster name presented to EDS
+			// https://github.com/envoyproxy/go-control-plane/blob/c7e2a120463a2209c6a0871d778f4eab96457e6b/envoy/api/v2/cds.pb.go#L1047
+			//
+			// map[cluster-name] => service-name
+			streamCache[stId][v.Name] = v.GetEdsClusterConfig().GetServiceName()
+
+		case *envoy_api_v2.ClusterLoadAssignment:
+			nb := len(v.GetEndpoints())
+			current, _ := strconv.Atoi(streamCache[stId]["total"])
+			streamCache[stId]["total"] = strconv.Itoa(current + nb)
+
+		case *envoy_api_v2.Listener:
+			streamCache[stId][v.Name] = "known"
+
+		case *envoy_api_v2.RouteConfiguration:
+			// not caching routes for now
+
+		case *envoy_api_v2_auth.Secret:
+			// not caching secrets for now
+
+		default:
+			// fmt.Println("no idea what to cache", v)
+		}
+	}
+}
+
+func lessProtoMessage(x, y proto.Message) bool {
+	switch xm := x.(type) {
+	case *envoy_api_v2.Cluster:
+		ym := y.(*envoy_api_v2.Cluster)
+		return xm.Name < ym.Name
+	case *envoy_api_v2.Listener:
+		ym := y.(*envoy_api_v2.Listener)
+		return xm.Name < ym.Name
+	default:
+		return true
+	}
+}
 
 func hash(data []proto.Message) string {
 	jsonBytes, _ := json.Marshal(data)


### PR DESCRIPTION
Changes needed to allow us to run the unit-tests. Non-tests changes are:
- `internal/grpc/xds.go`: cleanup + ability to disable xDS ordering
- `internal/envoy/route.go`:  I restored the upstream func signature (used by a lot of tests) and create a custom one for our needs

All the other changes are in the tests files: I've tried to keep these to a minimum to avoid merge conflicts. While there are lots of files involved, I expect them to just merge when we bring in upstream.

There are no new tests in this PR (I'll file separately); I wanted to get this going and reviewed