### PR TITLE
unit tests for adobe customization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ test-race: | test
 test-adobe:
 	CIDR_LIST_PATH= ZZZ_NO_SYNC_XDS=true go test -count=1 -mod=readonly $(MODULE)/...
 
+test-adobe-only:
+	CIDR_LIST_PATH= ZZZ_NO_SYNC_XDS=true go test -count=1 -mod=readonly $(MODULE)/... --run TestAdobe
+
 vet: | test
 	go vet $(MODULE)/...
 

--- a/internal/e2e/adobe_test.go
+++ b/internal/e2e/adobe_test.go
@@ -1,0 +1,1690 @@
+// Note when writing tests:
+// assertEqualAdobe() and assertRDSAdobe() will perform the Adobe fixup
+// use assertEqualUpstream() and assertRDSUpstream() are the original one
+//
+// tests are organized by their name: TestAdobe{Cluster|Listener|Route}...
+// this is so we can filter via "--run TestAdobeCluster" etc.
+
+package e2e
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	http "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/duration"
+	_struct "github.com/golang/protobuf/ptypes/struct"
+	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
+	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// ==== IngressRoute CRD customization ====
+// == Route
+// HashPolicy []HashPolicy `json:"hashPolicy,omitempty"`
+// PerFilterConfig *PerFilterConfig `json:"perFilterConfig,omitempty"`
+// Timeout *Duration `json:"timeout,omitempty"`
+// IdleTimeout *Duration `json:"idleTimeout,omitempty"`
+//
+// == Service
+// IdleTimeout *Duration `json:"idleTimeout,omitempty"`
+
+// NOTE: we're testing CRD-specific properties: these tests can use the
+// fixup functions.
+
+func TestAdobeRouteHashPolicy(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "hashpolicy.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+				HashPolicy: []ingressroutev1.HashPolicy{
+					{
+						Header: &ingressroutev1.HashPolicyHeader{
+							HeaderName: "x-some-header",
+						},
+					},
+					{
+						Cookie: &ingressroutev1.HashPolicyCookie{
+							Name: "nom-nom-nom",
+						},
+						Terminal: true,
+					},
+					{
+						ConnectionProperties: &ingressroutev1.HashPolicyConnectionProperties{
+							SourceIp: true,
+						},
+					},
+				},
+			}},
+		},
+	})
+
+	r := routecluster("default/ws/80/da39a3ee5e")
+	r.Route.HashPolicy = make([]*envoy_api_v2_route.RouteAction_HashPolicy, 3)
+	r.Route.HashPolicy[0] = &envoy_api_v2_route.RouteAction_HashPolicy{
+		PolicySpecifier: &envoy_api_v2_route.RouteAction_HashPolicy_Header_{
+			Header: &envoy_api_v2_route.RouteAction_HashPolicy_Header{
+				HeaderName: "x-some-header",
+			},
+		},
+	}
+	r.Route.HashPolicy[1] = &envoy_api_v2_route.RouteAction_HashPolicy{
+		PolicySpecifier: &envoy_api_v2_route.RouteAction_HashPolicy_Cookie_{
+			Cookie: &envoy_api_v2_route.RouteAction_HashPolicy_Cookie{
+				Name: "nom-nom-nom",
+			},
+		},
+		Terminal: true,
+	}
+	r.Route.HashPolicy[2] = &envoy_api_v2_route.RouteAction_HashPolicy{
+		PolicySpecifier: &envoy_api_v2_route.RouteAction_HashPolicy_ConnectionProperties_{
+			ConnectionProperties: &envoy_api_v2_route.RouteAction_HashPolicy_ConnectionProperties{
+				SourceIp: true,
+			},
+		},
+	}
+
+	assertRDSAdobe(t, cc, "1", virtualhosts(
+		envoy.VirtualHost("hashpolicy.hello.world", envoy.Route(envoy.RoutePrefix("/"), r)),
+	), nil)
+}
+
+func TestAdobeRoutePerFilterConfigAllowDeny(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "perfilterconfig-allow-deny.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+				PerFilterConfig: &ingressroutev1.PerFilterConfig{
+					IpAllowDeny: &ingressroutev1.IpAllowDenyCidrs{
+						AllowCidrs: []ingressroutev1.Cidr{
+							{
+								AddressPrefix: func() *string { s := "10.0.0.1"; return &s }(),
+								PrefixLen:     func() *intstr.IntOrString { i := intstr.FromInt(32); return &i }(),
+							},
+							{
+								AddressPrefix: func() *string { s := "10.0.0.2"; return &s }(),
+								PrefixLen:     func() *intstr.IntOrString { s := intstr.FromString("32"); return &s }(),
+							},
+						},
+						DenyCidrs: []ingressroutev1.Cidr{
+							{
+								AddressPrefix: func() *string { s := "10.0.0.3"; return &s }(),
+								PrefixLen:     func() *intstr.IntOrString { i := intstr.FromInt(32); return &i }(),
+							},
+						},
+					},
+				},
+			}},
+		},
+	})
+
+	r := envoy.Route(envoy.RoutePrefix("/"), routecluster("default/ws/80/da39a3ee5e"))
+	r.PerFilterConfig = map[string]*_struct.Struct{
+		"envoy.filters.http.ip_allow_deny": {
+			Fields: map[string]*_struct.Value{
+				"allow_cidrs": {
+					Kind: &_struct.Value_ListValue{
+						ListValue: &_struct.ListValue{
+							Values: []*_struct.Value{
+								{
+									Kind: &_struct.Value_StructValue{
+										StructValue: &_struct.Struct{
+											Fields: map[string]*_struct.Value{
+												"address_prefix": {
+													Kind: &_struct.Value_StringValue{
+														StringValue: "10.0.0.1",
+													},
+												},
+												"prefix_len": {
+													Kind: &_struct.Value_NumberValue{
+														NumberValue: float64(32),
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Kind: &_struct.Value_StructValue{
+										StructValue: &_struct.Struct{
+											Fields: map[string]*_struct.Value{
+												"address_prefix": {
+													Kind: &_struct.Value_StringValue{
+														StringValue: "10.0.0.2",
+													},
+												},
+												"prefix_len": {
+													Kind: &_struct.Value_StringValue{
+														StringValue: "32",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"deny_cidrs": {
+					Kind: &_struct.Value_ListValue{
+						ListValue: &_struct.ListValue{
+							Values: []*_struct.Value{
+								{
+									Kind: &_struct.Value_StructValue{
+										StructValue: &_struct.Struct{
+											Fields: map[string]*_struct.Value{
+												"address_prefix": {
+													Kind: &_struct.Value_StringValue{
+														StringValue: "10.0.0.3",
+													},
+												},
+												"prefix_len": {
+													Kind: &_struct.Value_NumberValue{
+														NumberValue: float64(32),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assertRDSAdobe(t, cc, "1", virtualhosts(
+		envoy.VirtualHost("perfilterconfig-allow-deny.hello.world", r),
+	), nil)
+}
+
+func TestAdobeRoutePerFilterConfigHeaderSize(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "perfilterconfig-header-size.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+				PerFilterConfig: &ingressroutev1.PerFilterConfig{
+					HeaderSize: &ingressroutev1.HeaderSize{
+						HeaderSize: struct {
+							MaxBytes *int `json:"max_bytes,omitempty"`
+						}{
+							MaxBytes: func() *int { i := 8192; return &i }(),
+						},
+					},
+				},
+			}},
+		},
+	})
+
+	r := envoy.Route(envoy.RoutePrefix("/"), routecluster("default/ws/80/da39a3ee5e"))
+	r.PerFilterConfig = map[string]*_struct.Struct{
+		"envoy.filters.http.header_size": {
+			Fields: map[string]*_struct.Value{
+				"header_size": {
+					Kind: &_struct.Value_StructValue{
+						StructValue: &_struct.Struct{
+							Fields: map[string]*_struct.Value{
+								"max_bytes": {
+									Kind: &_struct.Value_NumberValue{
+										NumberValue: float64(8192),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assertRDSAdobe(t, cc, "1", virtualhosts(
+		envoy.VirtualHost("perfilterconfig-header-size.hello.world", r),
+	), nil)
+}
+
+func TestAdobeRoutePerFilterConfigOrdered(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "perfilterconfig-ordered.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+				PerFilterConfig: &ingressroutev1.PerFilterConfig{
+					IpAllowDeny: &ingressroutev1.IpAllowDenyCidrs{ // unordered
+						AllowCidrs: []ingressroutev1.Cidr{
+							{
+								AddressPrefix: func() *string { s := "10.0.0.1"; return &s }(),
+								PrefixLen:     func() *intstr.IntOrString { i := intstr.FromInt(32); return &i }(),
+							},
+						},
+					},
+					HeaderSize: &ingressroutev1.HeaderSize{
+						HeaderSize: struct {
+							MaxBytes *int `json:"max_bytes,omitempty"`
+						}{
+							MaxBytes: func() *int { i := 8192; return &i }(),
+						},
+					},
+				},
+			}},
+		},
+	})
+
+	r := envoy.Route(envoy.RoutePrefix("/"), routecluster("default/ws/80/da39a3ee5e"))
+	r.PerFilterConfig = map[string]*_struct.Struct{
+		"envoy.filters.http.header_size": {
+			Fields: map[string]*_struct.Value{
+				"header_size": {
+					Kind: &_struct.Value_StructValue{
+						StructValue: &_struct.Struct{
+							Fields: map[string]*_struct.Value{
+								"max_bytes": {
+									Kind: &_struct.Value_NumberValue{
+										NumberValue: float64(8192),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"envoy.filters.http.ip_allow_deny": {
+			Fields: map[string]*_struct.Value{
+				"allow_cidrs": {
+					Kind: &_struct.Value_ListValue{
+						ListValue: &_struct.ListValue{
+							Values: []*_struct.Value{
+								{
+									Kind: &_struct.Value_StructValue{
+										StructValue: &_struct.Struct{
+											Fields: map[string]*_struct.Value{
+												"address_prefix": {
+													Kind: &_struct.Value_StringValue{
+														StringValue: "10.0.0.1",
+													},
+												},
+												"prefix_len": {
+													Kind: &_struct.Value_NumberValue{
+														NumberValue: float64(32),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assertRDSAdobe(t, cc, "1", virtualhosts(
+		envoy.VirtualHost("perfilterconfig-ordered.hello.world", r),
+	), nil)
+}
+
+func TestAdobeRouteTimeout(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "route-timeout.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+				Timeout: &ingressroutev1.Duration{
+					duration.Duration{
+						Seconds: int64(60),
+						Nanos:   int32(0),
+					},
+				},
+			}},
+		},
+	})
+
+	r := routecluster("default/ws/80/da39a3ee5e")
+	r.Route.Timeout = protobuf.Duration(60 * time.Second)
+
+	assertRDSAdobe(t, cc, "1", virtualhosts(
+		envoy.VirtualHost("route-timeout.hello.world", envoy.Route(envoy.RoutePrefix("/"), r)),
+	), nil)
+}
+
+func TestAdobeRouteIdleTimeout(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "route-timeout.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+				IdleTimeout: &ingressroutev1.Duration{
+					duration.Duration{
+						Seconds: int64(45),
+						Nanos:   int32(0),
+					},
+				},
+			}},
+		},
+	})
+
+	r := routecluster("default/ws/80/da39a3ee5e")
+	r.Route.IdleTimeout = protobuf.Duration(45 * time.Second)
+
+	assertRDSAdobe(t, cc, "1", virtualhosts(
+		envoy.VirtualHost("route-timeout.hello.world", envoy.Route(envoy.RoutePrefix("/"), r)),
+	), nil)
+}
+
+func TestAdobeRouteServiceTimeout(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "service-timeout.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+					IdleTimeout: &ingressroutev1.Duration{
+						duration.Duration{
+							Seconds: int64(55),
+							Nanos:   int32(0),
+						},
+					},
+				}},
+			}},
+		},
+	})
+
+	c := cluster("default/ws/80/da39a3ee5e", "default/ws", "default_ws_80")
+	c.CommonHttpProtocolOptions = &envoy_api_v2_core.HttpProtocolOptions{
+		IdleTimeout: protobuf.Duration(55 * time.Second),
+	}
+
+	assertEqualAdobe(t, &v2.DiscoveryResponse{
+		VersionInfo: "1",
+		Resources:   resources(t, c),
+		TypeUrl:     clusterType,
+		Nonce:       "1",
+	}, streamCDS(t, cc))
+}
+
+// ==== Hard-coded customization ====
+
+// == internal/contour/listener.go
+// remove stats listener
+// add custom listeners (with CIDR_LIST_PATH)
+// filter chain grouping
+
+func TestAdobeListenerRemoveStats(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "no-stats-listener.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+			}},
+		},
+	})
+
+	protos := []proto.Message{
+		&v2.Listener{
+			Name:         "ingress_http",
+			Address:      envoy.SocketAddress("0.0.0.0", 8080),
+			FilterChains: envoy.FilterChains(envoy.HTTPConnectionManager("ingress_http", envoy.FileAccessLogEnvoy("/dev/stdout"))),
+		},
+		// staticListener(), // upstream expects this!
+	}
+
+	assertEqualUpstream(t, &v2.DiscoveryResponse{
+		VersionInfo: hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     listenerType,
+		Nonce:       "1",
+	}, streamLDS(t, cc))
+}
+
+// TODO
+func TestAdobeListenerCustomListeners(t *testing.T) {
+	// TODO: configure the CIDR_LIST_PATH for all tests, ignore it instead of here?
+	// rh, cc, done := setup(t)
+	// defer done()
+	//
+	// // set up the env var
+	// os.Setenv("CIDR_LIST_PATH", "ip_allow_deny.json")
+	// defer os.Unsetenv("CIDR_LIST_PATH")
+}
+
+func TestAdobeListenerFilterChainGrouping(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	// grouping is by secret, so create a single one
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: "ns-secret",
+		},
+		Type: "kubernetes.io/tls",
+		Data: map[string][]byte{
+			v1.TLSCertKey:       []byte("certificate"),
+			v1.TLSPrivateKeyKey: []byte("key"),
+		},
+	}
+	rh.OnAdd(secret)
+
+	// delegation
+	rh.OnAdd(&ingressroutev1.TLSCertificateDelegation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "delegation",
+			Namespace: "ns-secret",
+		},
+		Spec: ingressroutev1.TLSCertificateDelegationSpec{
+			Delegations: []ingressroutev1.CertificateDelegation{{
+				SecretName: "secret",
+				TargetNamespaces: []string{
+					"*",
+				},
+			}},
+		},
+	})
+
+	// service 2 (so it's not in order)
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws2",
+			Namespace: "ns2",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       81,
+				TargetPort: intstr.FromInt(8081),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws2",
+			Namespace: "ns2",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "fc-group-svc2.hello.world",
+				TLS: &projcontour.TLS{
+					SecretName: "ns-secret/secret",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws2",
+					Port: 81,
+				}},
+			}},
+		},
+	})
+
+	// service 1
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws1",
+			Namespace: "ns1",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws1",
+			Namespace: "ns1",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "fc-group-svc1.hello.world",
+				TLS: &projcontour.TLS{
+					SecretName: "ns-secret/secret",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws1",
+					Port: 80,
+				}},
+			}},
+		},
+	})
+
+	protos := []proto.Message{
+		&v2.Listener{
+			Name:         "ingress_http",
+			Address:      envoy.SocketAddress("0.0.0.0", 8080),
+			FilterChains: envoy.FilterChains(envoy.HTTPConnectionManager("ingress_http", envoy.FileAccessLogEnvoy("/dev/stdout"))),
+		},
+		&v2.Listener{
+			Name:    "ingress_https",
+			Address: envoy.SocketAddress("0.0.0.0", 8443),
+			ListenerFilters: envoy.ListenerFilters(
+				envoy.TLSInspector(),
+			),
+			FilterChains: []*envoy_api_v2_listener.FilterChain{
+				{
+					Filters: envoy.Filters(envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"))),
+					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
+						ServerNames: []string{
+							"fc-group-svc1.hello.world",
+							"fc-group-svc2.hello.world",
+						},
+					},
+					TlsContext: envoy.DownstreamTLSContext(envoy.Secretname(&dag.Secret{Object: secret}), envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
+				},
+			},
+		},
+	}
+
+	assertEqualUpstream(t, &v2.DiscoveryResponse{
+		VersionInfo: hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     listenerType,
+		Nonce:       "3",
+	}, streamLDS(t, cc))
+}
+
+// A bug we introduced: don't group if the min TLS versions are different
+// The fixture is virtually identical to the previous test, but for the
+// min TLS protocol version on one of the ingress route
+func TestAdobeListenerFilterChainGroupingNotTLS(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	// grouping is by secret, so create a single one
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: "ns-secret",
+		},
+		Type: "kubernetes.io/tls",
+		Data: map[string][]byte{
+			v1.TLSCertKey:       []byte("certificate"),
+			v1.TLSPrivateKeyKey: []byte("key"),
+		},
+	}
+	rh.OnAdd(secret)
+
+	// delegation
+	rh.OnAdd(&ingressroutev1.TLSCertificateDelegation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "delegation",
+			Namespace: "ns-secret",
+		},
+		Spec: ingressroutev1.TLSCertificateDelegationSpec{
+			Delegations: []ingressroutev1.CertificateDelegation{{
+				SecretName: "secret",
+				TargetNamespaces: []string{
+					"*",
+				},
+			}},
+		},
+	})
+
+	// service 2 (so it's not in order)
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws2",
+			Namespace: "ns2",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       81,
+				TargetPort: intstr.FromInt(8081),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws2",
+			Namespace: "ns2",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "fc-group-svc2.hello.world",
+				TLS: &projcontour.TLS{
+					SecretName: "ns-secret/secret",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws2",
+					Port: 81,
+				}},
+			}},
+		},
+	})
+
+	// service 1
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws1",
+			Namespace: "ns1",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws1",
+			Namespace: "ns1",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "fc-group-svc1.hello.world",
+				TLS: &projcontour.TLS{
+					SecretName:             "ns-secret/secret",
+					MinimumProtocolVersion: "1.3", // Different min version !!
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws1",
+					Port: 80,
+				}},
+			}},
+		},
+	})
+
+	protos := []proto.Message{
+		&v2.Listener{
+			Name:         "ingress_http",
+			Address:      envoy.SocketAddress("0.0.0.0", 8080),
+			FilterChains: envoy.FilterChains(envoy.HTTPConnectionManager("ingress_http", envoy.FileAccessLogEnvoy("/dev/stdout"))),
+		},
+		&v2.Listener{
+			Name:    "ingress_https",
+			Address: envoy.SocketAddress("0.0.0.0", 8443),
+			ListenerFilters: envoy.ListenerFilters(
+				envoy.TLSInspector(),
+			),
+			FilterChains: []*envoy_api_v2_listener.FilterChain{
+				envoy.FilterChainTLS("fc-group-svc1.hello.world", &dag.Secret{Object: secret}, envoy.Filters(envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"))), envoy_api_v2_auth.TlsParameters_TLSv1_3, "h2", "http/1.1"),
+				envoy.FilterChainTLS("fc-group-svc2.hello.world", &dag.Secret{Object: secret}, envoy.Filters(envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"))), envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
+			},
+		},
+	}
+
+	assertEqualUpstream(t, &v2.DiscoveryResponse{
+		VersionInfo: hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     listenerType,
+		Nonce:       "3",
+	}, streamLDS(t, cc))
+}
+
+// == internal/dag/builder.go
+// re-allow root to root delegation
+// disable TLS 1.1
+
+// Test the whole scenario: delegation created in a separate ns with a different secret
+func TestAdobeListenerRootToRootDelegation(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	secret1 := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret1",
+			Namespace: "default",
+		},
+		Type: "kubernetes.io/tls",
+		Data: map[string][]byte{
+			v1.TLSCertKey:       []byte("certificate"),
+			v1.TLSPrivateKeyKey: []byte("key"),
+		},
+	}
+	rh.OnAdd(secret1)
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "root",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "roottoroot-root.hello.world",
+				TLS: &projcontour.TLS{
+					SecretName: "secret1",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+			}},
+		},
+	})
+
+	secret2 := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret2",
+			Namespace: "some-other-ns",
+		},
+		Type: "kubernetes.io/tls",
+		Data: map[string][]byte{
+			v1.TLSCertKey:       []byte("certificate"),
+			v1.TLSPrivateKeyKey: []byte("key"),
+		},
+	}
+	rh.OnAdd(secret2)
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "delegate",
+			Namespace: "some-other-ns",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "roottoroot-dele.hello.world",
+				TLS: &projcontour.TLS{
+					SecretName: "secret2",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Delegate: &ingressroutev1.Delegate{
+					Name:      "root",
+					Namespace: "default",
+				},
+			}},
+		},
+	})
+
+	protos := []proto.Message{
+		&v2.Listener{
+			Name:         "ingress_http",
+			Address:      envoy.SocketAddress("0.0.0.0", 8080),
+			FilterChains: envoy.FilterChains(envoy.HTTPConnectionManager("ingress_http", envoy.FileAccessLogEnvoy("/dev/stdout"))),
+		},
+		&v2.Listener{
+			Name:    "ingress_https",
+			Address: envoy.SocketAddress("0.0.0.0", 8443),
+			ListenerFilters: envoy.ListenerFilters(
+				envoy.TLSInspector(),
+			),
+			FilterChains: []*envoy_api_v2_listener.FilterChain{
+				// "dele" first because of ordering
+				envoy.FilterChainTLS("roottoroot-dele.hello.world", &dag.Secret{Object: secret2}, envoy.Filters(envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"))), envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
+				envoy.FilterChainTLS("roottoroot-root.hello.world", &dag.Secret{Object: secret1}, envoy.Filters(envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"))), envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
+			},
+		},
+	}
+
+	assertEqualUpstream(t, &v2.DiscoveryResponse{
+		VersionInfo: hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     listenerType,
+		Nonce:       "2",
+	}, streamLDS(t, cc))
+}
+
+func TestAdobeListenerDisableTLS1_1(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: "ns",
+		},
+		Type: "kubernetes.io/tls",
+		Data: map[string][]byte{
+			v1.TLSCertKey:       []byte("certificate"),
+			v1.TLSPrivateKeyKey: []byte("key"),
+		},
+	}
+	rh.OnAdd(secret)
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "ns",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8081),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "ns",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "no-tls-1-1.hello.world",
+				TLS: &projcontour.TLS{
+					SecretName:             "secret",
+					MinimumProtocolVersion: "1.1",
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+			}},
+		},
+	})
+
+	protos := []proto.Message{
+		&v2.Listener{
+			Name:         "ingress_http",
+			Address:      envoy.SocketAddress("0.0.0.0", 8080),
+			FilterChains: envoy.FilterChains(envoy.HTTPConnectionManager("ingress_http", envoy.FileAccessLogEnvoy("/dev/stdout"))),
+		},
+		&v2.Listener{
+			Name:    "ingress_https",
+			Address: envoy.SocketAddress("0.0.0.0", 8443),
+			ListenerFilters: envoy.ListenerFilters(
+				envoy.TLSInspector(),
+			),
+			FilterChains: []*envoy_api_v2_listener.FilterChain{
+				envoy.FilterChainTLS("no-tls-1-1.hello.world", &dag.Secret{Object: secret}, envoy.Filters(envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"))), envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
+			},
+		},
+	}
+
+	assertEqualUpstream(t, &v2.DiscoveryResponse{
+		VersionInfo: hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     listenerType,
+		Nonce:       "1",
+	}, streamLDS(t, cc))
+}
+
+// == internal/dag/cache.go
+// enforce class annotation
+// TODO(lrouquet) - hard to test, easy to verify: skipping for now
+
+// == internal/envoy/cluster.go
+// add CircuitBreakers
+// add DrainConnectionsOnHostRemoval
+// Cluster_LbPolicy changes: remove Cookie/replace with RingHash, add MagLev
+
+// test both at the same time since they're both added
+func TestAdobeClusterCircuitBreakersDrainConnections(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "circuitbreaker-drain.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+			}},
+		},
+	})
+
+	c := cluster("default/ws/80/da39a3ee5e", "default/ws", "default_ws_80")
+	c.CircuitBreakers = circuitBreakers // use the one in e2e_adobe.go
+	c.DrainConnectionsOnHostRemoval = true
+
+	protos := []proto.Message{c}
+
+	assertEqualUpstream(t, &v2.DiscoveryResponse{
+		VersionInfo: hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     clusterType,
+		Nonce:       "1",
+	}, streamCDS(t, cc))
+}
+
+// Cookie should now be default (so round robin)
+// RingHash is RingHash (was cookie)
+// Maglev is new
+func TestAdobeClusterLbPolicy(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws-cookie",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws-ringhash",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws-maglev",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "lb-policy.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{
+					{Name: "ws-cookie", Port: 80, Strategy: "Cookie"},
+					{Name: "ws-ringhash", Port: 80, Strategy: "RingHash"},
+					{Name: "ws-maglev", Port: 80, Strategy: "Maglev"},
+				},
+			}},
+		},
+	})
+
+	cCookie := cluster("default/ws-cookie/80/e4f81994fe", "default/ws-cookie", "default_ws-cookie_80")
+	cCookie.CircuitBreakers = circuitBreakers // use the one in e2e_adobe.go
+	cCookie.DrainConnectionsOnHostRemoval = true
+	cCookie.LbPolicy = v2.Cluster_ROUND_ROBIN
+
+	cRingHash := cluster("default/ws-ringhash/80/40633a6ca9", "default/ws-ringhash", "default_ws-ringhash_80")
+	cRingHash.CircuitBreakers = circuitBreakers // use the one in e2e_adobe.go
+	cRingHash.DrainConnectionsOnHostRemoval = true
+	cRingHash.LbPolicy = v2.Cluster_RING_HASH
+
+	cMagLev := cluster("default/ws-maglev/80/843e4ded8f", "default/ws-maglev", "default_ws-maglev_80")
+	cMagLev.CircuitBreakers = circuitBreakers // use the one in e2e_adobe.go
+	cMagLev.DrainConnectionsOnHostRemoval = true
+	cMagLev.LbPolicy = v2.Cluster_MAGLEV
+
+	protos := []proto.Message{cCookie, cMagLev, cRingHash} //ordered
+
+	assertEqualUpstream(t, &v2.DiscoveryResponse{
+		VersionInfo: hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     clusterType,
+		Nonce:       "1",
+	}, streamCDS(t, cc))
+}
+
+// == internal/envoy/healthcheck
+// add ExpectedStatuses
+
+func TestAdobeClusterHealthcheck(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "healthcheck.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+					HealthCheck: &projcontour.HealthCheck{
+						Path: "/health",
+					},
+				}},
+			}},
+		},
+	})
+
+	c := cluster("default/ws/80/0bb4da595b", "default/ws", "default_ws_80")
+	c.CircuitBreakers = circuitBreakers
+	c.DrainConnectionsOnHostRemoval = true
+	c.HealthChecks = []*envoy_api_v2_core.HealthCheck{
+		{
+			Timeout:            protobuf.Duration(2 * time.Second),
+			Interval:           protobuf.Duration(10 * time.Second),
+			UnhealthyThreshold: protobuf.UInt32(3),
+			HealthyThreshold:   protobuf.UInt32(2),
+			HealthChecker: &envoy_api_v2_core.HealthCheck_HttpHealthCheck_{
+				HttpHealthCheck: &envoy_api_v2_core.HealthCheck_HttpHealthCheck{
+					Path:             "/health",
+					Host:             "contour-envoy-healthcheck",
+					ExpectedStatuses: expectedStatuses,
+				},
+			},
+		},
+	}
+
+	protos := []proto.Message{c}
+
+	assertEqualUpstream(t, &v2.DiscoveryResponse{
+		VersionInfo: hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     clusterType,
+		Nonce:       "1",
+	}, streamCDS(t, cc))
+}
+
+// == internal/envoy/listener.go
+// add SocketOptions
+// HttpFilters updates:  remove gzip, grpc web, add ip_allow_deny, health_check_simple, headersize
+// add GenerateRequestId:   protobuf.Bool(false),
+// add MaxRequestHeadersKb: protobuf.UInt32(64),
+// remove IdleTimeout
+// remove PreserveExternalRequestId
+// add tracing
+
+func TestAdobeListenerSocketOptions(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	// set up the env var
+	os.Setenv("TCP_KEEPALIVE_ENABLED", "true")
+	os.Setenv("TCP_KEEPALIVE_IDLE", "35")
+	os.Setenv("TCP_KEEPALIVE_INTVL", "45")
+	os.Setenv("TCP_KEEPALIVE_CNT", "55")
+
+	defer func() {
+		os.Unsetenv("TCP_KEEPALIVE_ENABLED")
+		os.Unsetenv("TCP_KEEPALIVE_IDLE")
+		os.Unsetenv("TCP_KEEPALIVE_INTVL")
+		os.Unsetenv("TCP_KEEPALIVE_CNT")
+	}()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "socket-options.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+			}},
+		},
+	})
+
+	protos := []proto.Message{
+		&v2.Listener{
+			Name:         "ingress_http",
+			Address:      envoy.SocketAddress("0.0.0.0", 8080),
+			FilterChains: envoy.FilterChains(envoy.HTTPConnectionManager("ingress_http", envoy.FileAccessLogEnvoy("/dev/stdout"))),
+			SocketOptions: []*envoy_api_v2_core.SocketOption{
+				{
+					Level: 1,                                                     // SOL_SOCKET
+					Name:  9,                                                     // SO_KEEPALIVE
+					Value: &envoy_api_v2_core.SocketOption_IntValue{IntValue: 1}, // TCP_KEEPALIVE_ENABLED
+					State: envoy_api_v2_core.SocketOption_STATE_PREBIND,
+				},
+				{
+					Level: 6,                                                      // IPPROTO_TCP
+					Name:  4,                                                      // TCP_KEEPIDLE
+					Value: &envoy_api_v2_core.SocketOption_IntValue{IntValue: 35}, // TCP_KEEPALIVE_IDLE
+					State: envoy_api_v2_core.SocketOption_STATE_PREBIND,
+				},
+				{
+					Level: 6,                                                      // IPPROTO_TCP
+					Name:  5,                                                      // TCP_KEEPINTVL
+					Value: &envoy_api_v2_core.SocketOption_IntValue{IntValue: 45}, // TCP_KEEPALIVE_INTVL
+					State: envoy_api_v2_core.SocketOption_STATE_PREBIND,
+				},
+				{
+					Level: 6,                                                      // IPPROTO_TCP
+					Name:  6,                                                      // TCP_KEEPCNT
+					Value: &envoy_api_v2_core.SocketOption_IntValue{IntValue: 55}, // TCP_KEEPALIVE_CNT
+					State: envoy_api_v2_core.SocketOption_STATE_PREBIND,
+				},
+			},
+		},
+	}
+
+	assertEqualUpstream(t, &v2.DiscoveryResponse{
+		VersionInfo: hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     listenerType,
+		Nonce:       "1",
+	}, streamLDS(t, cc))
+}
+
+// test all of the rest in 1 swoop
+func TestAdobeListenerHttpConnectionManager(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	// set up the env var for tracing
+	os.Setenv("TRACING_ENABLED", "true")
+	os.Setenv("TRACING_OPERATION_NAME", "egress")
+	os.Setenv("TRACING_CLIENT_SAMPLING", "25")
+	os.Setenv("TRACING_RANDOM_SAMPLING", "35")
+	os.Setenv("TRACING_OVERALL_SAMPLING", "45")
+	os.Setenv("TRACING_VERBOSE", "false")
+
+	defer func() {
+		os.Unsetenv("TRACING_ENABLED")
+		os.Unsetenv("TRACING_OPERATION_NAME")
+		os.Unsetenv("TRACING_CLIENT_SAMPLING")
+		os.Unsetenv("TRACING_RANDOM_SAMPLING")
+		os.Unsetenv("TRACING_OVERALL_SAMPLING")
+		os.Unsetenv("TRACING_VERBOSE")
+	}()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "no-stats-listener.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+			}},
+		},
+	})
+
+	protos := []proto.Message{
+		&v2.Listener{
+			Name:    "ingress_http",
+			Address: envoy.SocketAddress("0.0.0.0", 8080),
+			FilterChains: []*envoy_api_v2_listener.FilterChain{
+				{
+					Filters: []*envoy_api_v2_listener.Filter{
+						{
+							Name: "envoy.http_connection_manager",
+							ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
+								TypedConfig: toAny(t, &http.HttpConnectionManager{
+									StatPrefix: "ingress_http",
+									RouteSpecifier: &http.HttpConnectionManager_Rds{
+										Rds: &http.Rds{
+											RouteConfigName: "ingress_http",
+											ConfigSource: &envoy_api_v2_core.ConfigSource{
+												ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_ApiConfigSource{
+													ApiConfigSource: &envoy_api_v2_core.ApiConfigSource{
+														ApiType: envoy_api_v2_core.ApiConfigSource_GRPC,
+														GrpcServices: []*envoy_api_v2_core.GrpcService{{
+															TargetSpecifier: &envoy_api_v2_core.GrpcService_EnvoyGrpc_{
+																EnvoyGrpc: &envoy_api_v2_core.GrpcService_EnvoyGrpc{
+																	ClusterName: "contour",
+																},
+															},
+														}},
+													},
+												},
+											},
+										},
+									},
+									GenerateRequestId:   protobuf.Bool(false),
+									MaxRequestHeadersKb: protobuf.UInt32(64),
+									HttpFilters: []*http.HttpFilter{
+										{
+											Name: "envoy.filters.http.ip_allow_deny",
+										},
+										{
+											Name: "envoy.filters.http.health_check_simple",
+											ConfigType: &http.HttpFilter_Config{
+												Config: &_struct.Struct{
+													Fields: map[string]*_struct.Value{
+														"path": {Kind: &_struct.Value_StringValue{StringValue: "/envoy_health_94eaa5a6ba44fc17d1da432d4a1e2d73"}},
+													},
+												}},
+										},
+										{
+											Name: "envoy.filters.http.header_size",
+											ConfigType: &http.HttpFilter_Config{
+												Config: &_struct.Struct{
+													Fields: map[string]*_struct.Value{
+														"max_bytes": {Kind: &_struct.Value_NumberValue{NumberValue: 64 * 1024}},
+													},
+												}},
+										},
+										{
+											Name: "envoy.router",
+										},
+									},
+									HttpProtocolOptions: &envoy_api_v2_core.Http1ProtocolOptions{
+										AcceptHttp_10: true,
+									},
+									AccessLog:        envoy.FileAccessLogEnvoy("/dev/stdout"),
+									UseRemoteAddress: protobuf.Bool(true),
+									NormalizePath:    protobuf.Bool(true),
+									Tracing: &http.HttpConnectionManager_Tracing{
+										OperationName:   http.HttpConnectionManager_Tracing_EGRESS,
+										ClientSampling:  &envoy_type.Percent{Value: 25},
+										RandomSampling:  &envoy_type.Percent{Value: 35},
+										OverallSampling: &envoy_type.Percent{Value: 45},
+										Verbose:         false,
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assertEqualUpstream(t, &v2.DiscoveryResponse{
+		VersionInfo: hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     listenerType,
+		Nonce:       "1",
+	}, streamLDS(t, cc))
+}
+
+// == internal/envoy/route.go
+// remove RouteAction.RetryPolicy
+// remove RouteHeader "x-request-start"
+// add VirtualHost.RetryPolicy
+
+func TestAdobeRoute(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "route.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+			}},
+		},
+	})
+
+	protos := []proto.Message{
+		&v2.RouteConfiguration{
+			Name: "ingress_http",
+			VirtualHosts: []*envoy_api_v2_route.VirtualHost{
+				{
+					Name: "route.hello.world",
+					Domains: []string{
+						"route.hello.world",
+						"route.hello.world:*",
+					},
+					Routes: []*envoy_api_v2_route.Route{
+						{
+							Match:  envoy.RoutePrefix("/"),
+							Action: routecluster("default/ws/80/da39a3ee5e"),
+						},
+					},
+					RetryPolicy: &envoy_api_v2_route.RetryPolicy{
+						RetryOn:                       "connect-failure",
+						NumRetries:                    protobuf.UInt32(3),
+						HostSelectionRetryMaxAttempts: 3,
+					},
+				},
+			},
+		},
+		&v2.RouteConfiguration{
+			Name:         "ingress_https",
+			VirtualHosts: nil,
+		},
+	}
+
+	assertEqualUpstream(t, &v2.DiscoveryResponse{
+		VersionInfo: hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     routeType,
+		Nonce:       "1",
+	}, streamRDS(t, cc))
+}

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -69,7 +69,8 @@ func (d *discardWriter) Write(buf []byte) (int, error) {
 }
 
 func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEventHandler, *grpc.ClientConn, func()) {
-	t.Parallel()
+	// Adobe - conflicts with tests using environment variables
+	// t.Parallel()
 
 	log := logrus.New()
 	log.Out = &testWriter{t}
@@ -287,9 +288,7 @@ func (r *Response) Equals(want *v2.DiscoveryResponse) {
 	assertEqual(r.T, want, r.DiscoveryResponse)
 }
 
-func assertEqual(t *testing.T, want, got *v2.DiscoveryResponse) {
-	// Modify with Adobe customizations
-	adobefyXDS(t, want)
+func assertEqualUpstream(t *testing.T, want, got *v2.DiscoveryResponse) {
 	t.Helper()
 	m := proto.TextMarshaler{Compact: true, ExpandAny: true}
 	a := m.Text(want)


### PR DESCRIPTION
As far as I can tell, this covers everything but
- gRPC keep alive
- filter via CIDR_LIST_PATH

The latter is hard because it's all initialized via `init()` breaking other tests. There are some changes in contour 1.0 that will help (abstraction of assert), so I'll add that test then.

I had trouble with the renaming, so feedback is welcome!

Make sure to use `test-adobe` and/or `test-adobe-only` make targets to run these tests.