### PR TITLE
fix: cds wait issue during xds sync

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,10 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## v1.1.0-2.2.1-adobe
+
+- fix cds sync issue causing the update to potentially wait indefinitely
+
 ## v1.1.0-2.2.0-adobe
 
 - protobuf updates


### PR DESCRIPTION
- when xDS synchronization is required, the routine will sleep for a moment in an effort prevent locking other routines it is waiting for
- for RDS, the latest cluster resources are used (fixes the issue where CDS may have changed while waiting)
- added a fail-safe to never wait indefinitely
- finally, if sync was in fact required, the latest resources are now sent in the xDS response