### PR TITLE
[improvement] eager load tls secrets only

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,10 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## v1.1.0-2.2.3-adobe
+
+- eager load tls secrets only
+
 ## v1.1.0-2.2.2-adobe
 
 - throttle logs when waiting for xDS updates


### PR DESCRIPTION
sync loading of resources on start now restrict secrets to type=tls only as a measure to speed up start up time. Certs hiding in secret type=opaque will still be discovered async by the informer.