### PR TITLE
adobe tests fixup

### DIFF
--- a/adobe/xds.go
+++ b/adobe/xds.go
@@ -5,9 +5,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"testing"
+	"time"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoy_types "github.com/envoyproxy/go-control-plane/envoy/type"
 	envoy "github.com/envoyproxy/go-control-plane/pkg/cache"
@@ -24,6 +26,7 @@ const (
 // CDS customization
 // add CircuitBreakers
 // set DrainConnectionsOnHostRemoval
+// add IdleTimeout via CommonHttpProtocolOptions
 // cluster.IdleTimeout (TODO test)
 // add ExpectedStatuses
 
@@ -34,6 +37,10 @@ var (
 			MaxConnections: protobuf.UInt32(1000000),
 			MaxRequests:    protobuf.UInt32(1000000),
 		}},
+	}
+
+	CommonHttpProtocolOptions = &envoy_api_v2_core.HttpProtocolOptions{
+		IdleTimeout: protobuf.Duration(58 * time.Second),
 	}
 
 	ExpectedStatuses = []*envoy_types.Int64Range{
@@ -74,6 +81,7 @@ func AdobefyXDS(t *testing.T, resp *v2.DiscoveryResponse) {
 			cluster := c.(*v2.Cluster)
 			cluster.CircuitBreakers = CircuitBreakers
 			cluster.DrainConnectionsOnHostRemoval = true
+			cluster.CommonHttpProtocolOptions = CommonHttpProtocolOptions
 			if cluster.HealthChecks != nil {
 				for _, h := range cluster.HealthChecks {
 					h.GetHttpHealthCheck().ExpectedStatuses = ExpectedStatuses

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -1038,10 +1038,6 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 					}
 				}
 
-				if c.IdleTimeout == nil {
-					c.IdleTimeout = ptypes.DurationProto(58 * time.Second)
-				}
-
 				r.Clusters = append(r.Clusters, c)
 			}
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/projectcontour/contour/adobe"
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
@@ -5931,6 +5932,8 @@ func TestDAGInsert(t *testing.T) {
 			}
 			opts := []cmp.Option{
 				cmp.AllowUnexported(VirtualHost{}),
+				// add here to prevent import cycle
+				cmpopts.IgnoreFields(Cluster{}, "IdleTimeout"),
 			}
 			opts = append(opts, adobe.IgnoreFields()...)
 			if diff := cmp.Diff(want, got, opts...); diff != "" {

--- a/internal/e2e/adobe_test.go
+++ b/internal/e2e/adobe_test.go
@@ -1212,9 +1212,7 @@ func TestAdobeClusterCircuitBreakersDrainConnections(t *testing.T) {
 	c := cluster("default/ws/80/da39a3ee5e", "default/ws", "default_ws_80")
 	c.CircuitBreakers = adobe.CircuitBreakers
 	c.DrainConnectionsOnHostRemoval = true
-	c.CommonHttpProtocolOptions = &envoy_api_v2_core.HttpProtocolOptions{
-		IdleTimeout: protobuf.Duration(58 * time.Second),
-	}
+	c.CommonHttpProtocolOptions = adobe.CommonHttpProtocolOptions
 
 	protos := []proto.Message{c}
 
@@ -1297,25 +1295,19 @@ func TestAdobeClusterLbPolicy(t *testing.T) {
 	cCookie.CircuitBreakers = adobe.CircuitBreakers
 	cCookie.DrainConnectionsOnHostRemoval = true
 	cCookie.LbPolicy = v2.Cluster_ROUND_ROBIN
-	cCookie.CommonHttpProtocolOptions = &envoy_api_v2_core.HttpProtocolOptions{
-		IdleTimeout: protobuf.Duration(58 * time.Second),
-	}
+	cCookie.CommonHttpProtocolOptions = adobe.CommonHttpProtocolOptions
 
 	cRingHash := cluster("default/ws-ringhash/80/40633a6ca9", "default/ws-ringhash", "default_ws-ringhash_80")
 	cRingHash.CircuitBreakers = adobe.CircuitBreakers
 	cRingHash.DrainConnectionsOnHostRemoval = true
 	cRingHash.LbPolicy = v2.Cluster_RING_HASH
-	cRingHash.CommonHttpProtocolOptions = &envoy_api_v2_core.HttpProtocolOptions{
-		IdleTimeout: protobuf.Duration(58 * time.Second),
-	}
+	cRingHash.CommonHttpProtocolOptions = adobe.CommonHttpProtocolOptions
 
 	cMagLev := cluster("default/ws-maglev/80/843e4ded8f", "default/ws-maglev", "default_ws-maglev_80")
 	cMagLev.CircuitBreakers = adobe.CircuitBreakers
 	cMagLev.DrainConnectionsOnHostRemoval = true
 	cMagLev.LbPolicy = v2.Cluster_MAGLEV
-	cMagLev.CommonHttpProtocolOptions = &envoy_api_v2_core.HttpProtocolOptions{
-		IdleTimeout: protobuf.Duration(58 * time.Second),
-	}
+	cMagLev.CommonHttpProtocolOptions = adobe.CommonHttpProtocolOptions
 
 	protos := []proto.Message{cCookie, cMagLev, cRingHash} //ordered
 
@@ -1386,9 +1378,7 @@ func TestAdobeClusterHealthcheck(t *testing.T) {
 			},
 		},
 	}
-	c.CommonHttpProtocolOptions = &envoy_api_v2_core.HttpProtocolOptions{
-		IdleTimeout: protobuf.Duration(58 * time.Second),
-	}
+	c.CommonHttpProtocolOptions = adobe.CommonHttpProtocolOptions
 
 	protos := []proto.Message{c}
 

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -25,6 +25,7 @@ import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -69,10 +70,11 @@ func Cluster(c *dag.Cluster) *v2.Cluster {
 		cluster.LoadAssignment = StaticClusterLoadAssignment(service)
 	}
 
-	if c.IdleTimeout != nil {
-		cluster.CommonHttpProtocolOptions = &envoy_api_v2_core.HttpProtocolOptions{
-			IdleTimeout: c.IdleTimeout,
-		}
+	if c.IdleTimeout == nil {
+		c.IdleTimeout = ptypes.DurationProto(58 * time.Second)
+	}
+	cluster.CommonHttpProtocolOptions = &envoy_api_v2_core.HttpProtocolOptions{
+		IdleTimeout: c.IdleTimeout,
 	}
 
 	// Drain connections immediately if using healthchecks and the endpoint is known to be removed


### PR DESCRIPTION
- moved default idleTimeout to be set in `envoy/cluster.go` so it applies to all resources, not just ingressroute.
- fixed the other tests