### PR TITLE
fix for malformed JSON duration values

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,10 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## v1.1.0-2.6.1-adobe
+
+- fix for rendering protobuf Duration objects when marshaling JSON
+
 ## v1.1.0-2.6.0-adobe
 
 - invalidate IRs with idle timeouts <= 0

--- a/apis/contour/v1beta1/ingressroute_adobe.go
+++ b/apis/contour/v1beta1/ingressroute_adobe.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	ptypes "github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -15,7 +16,14 @@ type Duration struct {
 }
 
 func (recv Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(recv.String())
+	// convert the protobuf.Duration back to a time.Duration
+	timeDuration, err := ptypes.Duration(&recv.Duration)
+	// if there was an error with the conversion, return the
+	// marshalled duration.Duration instead (old behavior)
+	if err != nil {
+		return json.Marshal(recv.String())
+	}
+	return json.Marshal(timeDuration.String())
 }
 
 func (recv *Duration) UnmarshalJSON(bs []byte) (err error) {


### PR DESCRIPTION
Duration types went from being a time.Duration to a protobuf Duration between v0.15 and v1.1.  That change created an unintended consequence when creating IngressRoutes using the Contour API's, where the marshaled JSON is malformed for those types.  For example, an IdleTimeout setting of `{Seconds:60}` results in:
```
idleTimeout: seconds:60
```
when the expected rendering should be:
```
idleTimeout: 60s
```
This PR converts the protobuf Duration back to a time.Duration before marshaling to JSON so that the string interpretation is correctly rendered.