### PR TITLE
Enable panic mode; health check failure logging

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,11 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## (unreleased)
+
+- enable panic mode
+- log health check failures, when enabled
+
 ## v1.3.0-2.6.1-adobe
 
 - built from contour v1.3.0

--- a/adobe/adobe.go
+++ b/adobe/adobe.go
@@ -15,6 +15,7 @@ import (
 // ignore properties added/removed by our customization
 var ignoreProperties = []cmp.Option{
 	cmpopts.IgnoreFields(v2.Cluster{}, "CommonHttpProtocolOptions", "CircuitBreakers", "DrainConnectionsOnHostRemoval"),
+	cmpopts.IgnoreFields(v2.Cluster_CommonLbConfig{}, "HealthyPanicThreshold"),
 	cmpopts.IgnoreFields(v2.RouteConfiguration{}, "RequestHeadersToAdd"),
 	cmpopts.IgnoreFields(envoy_api_v2_core.HealthCheck_HttpHealthCheck{}, "ExpectedStatuses"),
 	cmpopts.IgnoreFields(envoy_api_v2_route.RouteAction{}, "RetryPolicy", "Timeout", "IdleTimeout", "HashPolicy"),

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -291,10 +291,11 @@ func u32nil(val uint32) *wrappers.UInt32Value {
 }
 
 // ClusterCommonLBConfig creates a *v2.Cluster_CommonLbConfig with HealthyPanicThreshold disabled.
+// Adobe - enable HealthyPanicThreshold
 func ClusterCommonLBConfig() *v2.Cluster_CommonLbConfig {
 	return &v2.Cluster_CommonLbConfig{
 		HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
-			Value: 0,
+			Value: 100,
 		},
 	}
 }


### PR DESCRIPTION
- to my surprise, panic mode was disabled in contour; this PR re-enables that.
- added health check failure logging, enabled via an env variable