### PR TITLE
add maximumProtocolVersion to IngressRoute

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -18,8 +18,8 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 ## unreleased
 
-- configure InitialJitter
-- configure IntervalJitterPercent
+- configure InitialJitter & IntervalJitterPercent
+- add support for MaximumProtocolVersion on IngressRoute
 
 ## v1.3.0-2.7.0-adobe
 

--- a/adobe/adobe.go
+++ b/adobe/adobe.go
@@ -2,6 +2,7 @@ package adobe
 
 import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/google/go-cmp/cmp"
@@ -17,6 +18,7 @@ var ignoreProperties = []cmp.Option{
 	cmpopts.IgnoreFields(v2.Cluster{}, "CommonHttpProtocolOptions", "CircuitBreakers", "DrainConnectionsOnHostRemoval"),
 	cmpopts.IgnoreFields(v2.Cluster_CommonLbConfig{}, "HealthyPanicThreshold"),
 	cmpopts.IgnoreFields(v2.RouteConfiguration{}, "RequestHeadersToAdd"),
+	cmpopts.IgnoreFields(envoy_api_v2_auth.TlsParameters{}, "TlsMaximumProtocolVersion"),
 	cmpopts.IgnoreFields(envoy_api_v2_core.HealthCheck_HttpHealthCheck{}, "ExpectedStatuses"),
 	cmpopts.IgnoreFields(envoy_api_v2_route.RouteAction{}, "RetryPolicy", "Timeout", "IdleTimeout", "HashPolicy"),
 	cmpopts.IgnoreFields(envoy_api_v2_route.VirtualHost{}, "RetryPolicy"),

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -115,6 +115,9 @@ type TLS struct {
 	// Minimum TLS version this vhost should negotiate
 	// +optional
 	MinimumProtocolVersion string `json:"minimumProtocolVersion,omitempty"`
+	// Maximum TLS version this vhost should negotiate
+	// +optional
+	MaximumProtocolVersion string `json:"maximumProtocolVersion,omitempty"`
 	// If Passthrough is set to true, the SecretName will be ignored
 	// and the encrypted handshake will be passed through to the
 	// backing cluster.

--- a/internal/contour/listener_adobe.go
+++ b/internal/contour/listener_adobe.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	udpa_type_v1 "github.com/cncf/udpa/go/udpa/type/v1"
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
@@ -113,4 +114,12 @@ func CustomListenerFilters() []*envoy_api_v2_listener.ListenerFilter {
 		return []*envoy_api_v2_listener.ListenerFilter{}
 	}
 	return []*envoy_api_v2_listener.ListenerFilter{ipAllowDenyListenerFilter}
+}
+
+// maxProtoVersion returns the max supported version if the given version is TLS_AUTO
+func maxProtoVersion(version envoy_api_v2_auth.TlsParameters_TlsProtocol) envoy_api_v2_auth.TlsParameters_TlsProtocol {
+	if version == envoy_api_v2_auth.TlsParameters_TLS_AUTO {
+		return envoy_api_v2_auth.TlsParameters_TLSv1_3
+	}
+	return version
 }

--- a/internal/dag/annotations_adobe.go
+++ b/internal/dag/annotations_adobe.go
@@ -1,0 +1,18 @@
+package dag
+
+import (
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+)
+
+// MaxProtoVersion - similar to MinProtoVersion, but for a max
+// Note: upstream hard-code the version here, but internally uses TLS_AUTO
+// Then they have to configure the version in all their tests. We do what they
+// intended to do and return TLS_AUTO here; actual config happens in DownstreamTLSContext (internal/envoy)
+func MaxProtoVersion(version string) envoy_api_v2_auth.TlsParameters_TlsProtocol {
+	switch version {
+	case "1.2":
+		return envoy_api_v2_auth.TlsParameters_TLSv1_2
+	default:
+		return envoy_api_v2_auth.TlsParameters_TLS_AUTO
+	}
+}

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -421,6 +421,7 @@ func (b *Builder) computeIngressRoute(ir *ingressroutev1.IngressRoute) {
 			svhost := b.lookupSecureVirtualHost(ir.Spec.VirtualHost.Fqdn)
 			svhost.Secret = sec
 			svhost.MinProtoVersion = MinProtoVersion(ir.Spec.VirtualHost.TLS.MinimumProtocolVersion)
+			svhost.MaxProtoVersion = MaxProtoVersion(ir.Spec.VirtualHost.TLS.MaximumProtocolVersion)
 			enforceTLS = true
 		}
 		// passthrough is true if tls.secretName is not present, and

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -249,6 +249,9 @@ type SecureVirtualHost struct {
 	// TLS minimum protocol version. Defaults to envoy_api_v2_auth.TlsParameters_TLS_AUTO
 	MinProtoVersion envoy_api_v2_auth.TlsParameters_TlsProtocol
 
+	// TLS maximum protocol version. Defaults to envoy_api_v2_auth.TlsParameters_TLS_AUTO
+	MaxProtoVersion envoy_api_v2_auth.TlsParameters_TlsProtocol
+
 	// The cert and key for this host.
 	Secret *Secret
 

--- a/internal/envoy/auth_adobe.go
+++ b/internal/envoy/auth_adobe.go
@@ -8,21 +8,18 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 )
 
-// Retrieve the secret name attached to the given DownstreamTlsContext
-// Since we created it, we know there's only one!
-func RetrieveSecretName(transSocket *envoy_api_v2_core.TransportSocket) string {
-	return getDownstreamTlsContext(transSocket.GetTypedConfig()).CommonTlsContext.TlsCertificateSdsSecretConfigs[0].Name
+// DownstreamTLSContextAdobe - same as upstream but handles tlsMaxProtoVersion
+func DownstreamTLSContextAdobe(secretName string, tlsMinProtoVersion envoy_api_v2_auth.TlsParameters_TlsProtocol, tlsMaxProtoVersion envoy_api_v2_auth.TlsParameters_TlsProtocol, alpnProtos ...string) *envoy_api_v2_auth.DownstreamTlsContext {
+	tls := DownstreamTLSContext(secretName, tlsMinProtoVersion, alpnProtos...)
+	tls.CommonTlsContext.TlsParams.TlsMaximumProtocolVersion = tlsMaxProtoVersion
+	return tls
 }
 
-// Retrieve the min TLS protocol version configured on the given DownstreamTlsContext
-func RetrieveMinTLSVersion(transSocket *envoy_api_v2_core.TransportSocket) envoy_api_v2_auth.TlsParameters_TlsProtocol {
-	return getDownstreamTlsContext(transSocket.GetTypedConfig()).CommonTlsContext.TlsParams.TlsMinimumProtocolVersion
-}
-
-// Shortcut to get both previous values in 1 swoop
-func RetrieveSecretNameAndMinTLSVersion(transSocket *envoy_api_v2_core.TransportSocket) (string, envoy_api_v2_auth.TlsParameters_TlsProtocol) {
+// Retrieve the secret name and TLS protocol version attached to the given DownstreamTlsContext
+// Since we created it, we know there's only secret!
+func RetrieveSecretNameAndTLSVersions(transSocket *envoy_api_v2_core.TransportSocket) (string, envoy_api_v2_auth.TlsParameters_TlsProtocol, envoy_api_v2_auth.TlsParameters_TlsProtocol) {
 	ctc := getDownstreamTlsContext(transSocket.GetTypedConfig()).CommonTlsContext
-	return ctc.TlsCertificateSdsSecretConfigs[0].Name, ctc.TlsParams.TlsMinimumProtocolVersion
+	return ctc.TlsCertificateSdsSecretConfigs[0].Name, ctc.TlsParams.TlsMinimumProtocolVersion, ctc.TlsParams.TlsMaximumProtocolVersion
 }
 
 func getDownstreamTlsContext(a *any.Any) *envoy_api_v2_auth.DownstreamTlsContext {


### PR DESCRIPTION
- CRD change: `maximumProtocolVersion` is added alongside the existing `minimumProtocolVersion`
- envoy doesn't care if maxTLS < minTLS (the listener updates just fine), so I didn't add any tests for that
