### PR TITLE
default tls server

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,10 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## unreleased
+
+- optional default TLS server
+
 ## v1.3.0-2.9.0-adobe
 
 - expose tracing config in IngressRoute

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -167,6 +167,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 				AccessLogType:          ctx.AccessLogFormat,
 				AccessLogFields:        ctx.AccessLogFields,
 				MinimumProtocolVersion: dag.MinProtoVersion(ctx.TLSConfig.MinimumProtocolVersion),
+				DefaultCertificate:     defaultCertificate(),
 				RequestTimeout:         ctx.RequestTimeout,
 			},
 			ListenerCache: contour.NewListenerCache(ctx.statsAddr, ctx.statsPort),

--- a/cmd/contour/serve_adobe.go
+++ b/cmd/contour/serve_adobe.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/k8s"
@@ -8,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// func initCache(client *kubernetes.Clientset, contourClient *clientset.Clientset, eh *contour.EventHandler, et *contour.EndpointsTranslator) error {
 func initCache(clients *k8s.Clients, eh *contour.EventHandler, et *contour.EndpointsTranslator) error {
 	eh.Info("starting cache initialization")
 
@@ -110,4 +111,8 @@ func initCache(clients *k8s.Clients, eh *contour.EventHandler, et *contour.Endpo
 
 	eh.Info("finished cache initialization")
 	return nil
+}
+
+func defaultCertificate() string {
+	return os.Getenv("DEFAULT_CERTIFICATE")
 }

--- a/internal/contour/secret_adobe.go
+++ b/internal/contour/secret_adobe.go
@@ -1,0 +1,35 @@
+package contour
+
+import (
+	"strings"
+
+	"github.com/projectcontour/contour/internal/dag"
+)
+
+type dagSecretVisitor struct {
+	secrets map[string]*dag.Secret
+}
+
+// visitSecretsAsDag() produces a map of *dag.Secret
+// somewhat similar to visitSecrets()
+func visitSecretsAsDag(root dag.Vertex) map[string]*dag.Secret {
+	sv := dagSecretVisitor{
+		secrets: make(map[string]*dag.Secret),
+	}
+	sv.visit(root)
+	return sv.secrets
+}
+
+func (v *dagSecretVisitor) visit(vertex dag.Vertex) {
+	switch svh := vertex.(type) {
+	case *dag.SecureVirtualHost:
+		if svh.Secret != nil {
+			name := strings.Join([]string{svh.Secret.Namespace(), svh.Secret.Name()}, "/")
+			if _, ok := v.secrets[name]; !ok {
+				v.secrets[name] = svh.Secret
+			}
+		}
+	default:
+		vertex.Visit(v.visit)
+	}
+}


### PR DESCRIPTION
Configure a default TLS server, similar to the [k8s-ingress-nginx](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-ssl-certificate) feature.

It is activated by setting the environment variable `DEFAULT_CERTIFICATE` to a known cert. On a typical ethos cluster, this would be set to `heptio-contour/cluster-ssl-public` for example.