### PR TITLE
Header Rewrite Policy support in IngressRoute

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,10 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## v1.3.0-2.11.0-adobe
+
+- expose RequestHeadersPolicy and ResponseHeadersPolicy config in IngressRoute
+
 ## v1.3.0-2.10.0-adobe
 
 - optional default TLS server

--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -67,6 +67,12 @@ type Route struct {
 	IdleTimeout *Duration `json:"idleTimeout,omitempty"`
 
 	Tracing *Tracing `json:"tracing,omitempty"`
+	// The policy for managing request headers during proxying
+	// +optional
+	RequestHeadersPolicy *projcontour.HeadersPolicy `json:"requestHeadersPolicy,omitempty"`
+	// The policy for managing response headers during proxying
+	// +optional
+	ResponseHeadersPolicy *projcontour.HeadersPolicy `json:"responseHeadersPolicy,omitempty"`
 }
 
 // TimeoutPolicy define the attributes associated with timeout

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -984,26 +984,6 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 				return
 			}
 
-			var req *HeadersPolicy
-			var resp *HeadersPolicy
-			if route.RequestHeadersPolicy != nil {
-				reqHP, err := headersPolicy(route.RequestHeadersPolicy, true /* allow Host */)
-				if err != nil {
-					sw.SetInvalid(err.Error())
-					return
-				}
-				req = reqHP
-			}
-
-			if route.ResponseHeadersPolicy != nil {
-				respHP, err := headersPolicy(route.ResponseHeadersPolicy, false /* disallow Host */)
-				if err != nil {
-					sw.SetInvalid(err.Error())
-					return
-				}
-				resp = respHP
-			}
-
 			permitInsecure := route.PermitInsecure && !b.DisablePermitInsecure
 			r := &Route{
 				PathCondition:   &PrefixCondition{Prefix: route.Match},
@@ -1014,15 +994,24 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 				RetryPolicy:     retryPolicy(route.RetryPolicy),
 				HashPolicy:      route.HashPolicy,
 				PerFilterConfig: route.PerFilterConfig,
-				// RequestHeadersPolicy:  req,
-				// ResponseHeadersPolicy: resp,
 			}
 
 			if route.RequestHeadersPolicy != nil {
-				r.RequestHeadersPolicy = req
+				reqHP, err := headersPolicy(route.RequestHeadersPolicy, true /* allow Host */)
+				if err != nil {
+					sw.SetInvalid(err.Error())
+					return
+				}
+				r.RequestHeadersPolicy = reqHP
 			}
+
 			if route.ResponseHeadersPolicy != nil {
-				r.ResponseHeadersPolicy = resp
+				respHP, err := headersPolicy(route.ResponseHeadersPolicy, false /* disallow Host */)
+				if err != nil {
+					sw.SetInvalid(err.Error())
+					return
+				}
+				r.ResponseHeadersPolicy = respHP
 			}
 
 			if route.IdleTimeout != nil {

--- a/internal/e2e/adobe_test.go
+++ b/internal/e2e/adobe_test.go
@@ -2242,10 +2242,8 @@ func TestAdobeRoute(t *testing.T) {
 }
 
 // == internal/envoy/route.go
-// add VirtualHost.RequestHeadersToAdd
-// add VirtualHost.RequestHeadersToRemove
-// add VirtualHost.ResponseHeadersToAdd
-// add VirtualHost.ResponseHeadersToRemove
+// add Route.RequestHeadersPolicy
+// add Route.ResponseHeadersPolicy
 
 func TestAdobeRouteHeaderRewritePolicy(t *testing.T) {
 	rh, cc, done := setup(t)

--- a/internal/e2e/adobe_test.go
+++ b/internal/e2e/adobe_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
 	_struct "github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/projectcontour/contour/adobe"
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -43,6 +44,8 @@ import (
 // Timeout *Duration `json:"timeout,omitempty"`
 // IdleTimeout *Duration `json:"idleTimeout,omitempty"`
 // Tracing *Tracing `json:"tracing,omitempty"`
+// RequestHeadersPolicy *HeadersPolicy `json:"requestHeadersPolicy,omitempty"`
+// ResponseHeadersPolicy *HeadersPolicy `json:"responseHeadersPolicy,omitempty"`
 //
 // == Service
 // IdleTimeout *Duration `json:"idleTimeout,omitempty"`
@@ -2214,6 +2217,163 @@ func TestAdobeRoute(t *testing.T) {
 						{
 							Match:  routePrefix("/"),
 							Action: routecluster("default/ws/80/da39a3ee5e"),
+						},
+					},
+					RetryPolicy: &envoy_api_v2_route.RetryPolicy{
+						RetryOn:                       "connect-failure",
+						NumRetries:                    protobuf.UInt32(3),
+						HostSelectionRetryMaxAttempts: 3,
+					},
+				},
+			},
+		},
+		&v2.RouteConfiguration{
+			Name:         "ingress_https",
+			VirtualHosts: nil,
+		},
+	}
+
+	assert.Equal(t, &v2.DiscoveryResponse{
+		VersionInfo: adobe.Hash(protos),
+		Resources:   resources(t, protos...),
+		TypeUrl:     routeType,
+		Nonce:       "1",
+	}, streamRDS(t, cc))
+}
+
+// == internal/envoy/route.go
+// add VirtualHost.RequestHeadersToAdd
+// add VirtualHost.RequestHeadersToRemove
+// add VirtualHost.ResponseHeadersToAdd
+// add VirtualHost.ResponseHeadersToRemove
+
+func TestAdobeRouteHeaderRewritePolicy(t *testing.T) {
+	rh, cc, done := setup(t)
+	defer done()
+
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ws",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	})
+
+	rh.OnAdd(&ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "route-header-rewrite.hello.world"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: "ws",
+					Port: 80,
+				}},
+				RequestHeadersPolicy: &projcontour.HeadersPolicy{
+					Set: []projcontour.HeaderValue{{
+						Name:  "In-Foo",
+						Value: "bar",
+					},
+						{
+							Name:  "Request-Header-Two-Insert",
+							Value: "InFooBarTheSecond",
+						}},
+					Remove: []string{
+						"Abbracadabra",
+						"In-Bar",
+						"In-Baz",
+					},
+				},
+				ResponseHeadersPolicy: &projcontour.HeadersPolicy{
+					Set: []projcontour.HeaderValue{{
+						Name:  "Out-Foo",
+						Value: "goodbye",
+					},
+						{
+							Name:  "Response-Header-Two-Insert",
+							Value: "OutFooBarTheSecond",
+						}},
+					Remove: []string{
+						"Out-Baz",
+						"Request-Header-Two-Insert",
+					},
+				},
+			}},
+		},
+	})
+
+	protos := []proto.Message{
+		&v2.RouteConfiguration{
+			Name: "ingress_http",
+			VirtualHosts: []*envoy_api_v2_route.VirtualHost{
+				{
+					Name: "route-header-rewrite.hello.world",
+					Domains: []string{
+						"route-header-rewrite.hello.world",
+						"route-header-rewrite.hello.world:*",
+					},
+					Routes: []*envoy_api_v2_route.Route{
+						{
+							Match:  routePrefix("/"),
+							Action: routecluster("default/ws/80/da39a3ee5e"),
+							RequestHeadersToAdd: []*envoy_api_v2_core.HeaderValueOption{
+								{
+									Header: &envoy_api_v2_core.HeaderValue{
+										Key:   "In-Foo",
+										Value: "bar",
+									},
+									Append: &wrappers.BoolValue{
+										Value: false,
+									},
+								},
+								{
+									Header: &envoy_api_v2_core.HeaderValue{
+										Key:   "Request-Header-Two-Insert",
+										Value: "InFooBarTheSecond",
+									},
+									Append: &wrappers.BoolValue{
+										Value: false,
+									},
+								},
+							},
+							RequestHeadersToRemove: []string{
+								"Abbracadabra",
+								"In-Bar",
+								"In-Baz",
+							},
+							ResponseHeadersToAdd: []*envoy_api_v2_core.HeaderValueOption{
+								{
+									Header: &envoy_api_v2_core.HeaderValue{
+										Key:   "Out-Foo",
+										Value: "goodbye",
+									},
+									Append: &wrappers.BoolValue{
+										Value: false,
+									},
+								},
+								{
+									Header: &envoy_api_v2_core.HeaderValue{
+										Key:   "Response-Header-Two-Insert",
+										Value: "OutFooBarTheSecond",
+									},
+									Append: &wrappers.BoolValue{
+										Value: false,
+									},
+								},
+							},
+							ResponseHeadersToRemove: []string{
+								"Out-Baz",
+								"Request-Header-Two-Insert",
+							},
 						},
 					},
 					RetryPolicy: &envoy_api_v2_route.RetryPolicy{


### PR DESCRIPTION
Add plumbing to IngressRoute to support header rewrite policies, matching the support that's already in Contour for HTTPProxy.