### PR TITLE
allow dynamic request/response headers

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,10 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## _unreleased_
+
+- allow dynamic values in custom request/response headers
+
 ## v1.5.1-2.11.1-adobe
 
 - built from contour v1.5.1

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -943,7 +943,8 @@ func determineSNI(routeRequestHeaders *HeadersPolicy, clusterRequestHeaders *Hea
 func escapeHeaderValue(value string) string {
 	// Envoy supports %-encoded variables, so literal %'s in the header's value must be escaped.  See:
 	// https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#custom-request-response-headers
-	return strings.Replace(value, "%", "%%", -1)
+	ret := strings.Replace(value, "%", "%%", -1)
+	return strings.Replace(ret, "__percent__", "%", -1)
 }
 
 func includeConditionsIdentical(includes []projcontour.Include) bool {


### PR DESCRIPTION
Came from a user request to get the downstream tls-version/cipher as a header. The IngressRoute can be configured like: 
```
...
spec:
  routes:
  - match: /
    requestHeadersPolicy:
      set:
      - name: x-forwarded-tls-version
        value: __percent__DOWNSTREAM_TLS_VERSION__percent__
      - name: x-forwarded-tls-cipher
        value: __percent__DOWNSTREAM_TLS_CIPHER__percent__
...
```