### PR TITLE
All all wildcard; upgrade go

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,11 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## v1.5.1-2.13.0-adobe
+
+- remove restriction on wildcard fqdn
+- upgrade go to 1.14.9
+
 ## v1.5.1-2.12.1-adobe
 
 - indirectly fix Envoy issue with percent value of 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.5 AS build
+FROM golang:1.14.9 AS build
 WORKDIR /contour
 
 ENV GOPROXY=https://proxy.golang.org

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -428,14 +428,11 @@ func (b *Builder) computeIngressRoute(ir *ingressroutev1.IngressRoute) {
 	}
 	sw.WithValue("vhost", host)
 
-	if strings.Contains(host, "*") {
-		// Adobe - we allow, but with a bit of validation:
-		// no top domain, no "*"
-		if !strings.HasPrefix(host, "*") || strings.Count(host, ".") < 3 {
-			sw.SetInvalid("Spec.VirtualHost.Fqdn %q is invalid", host)
-			return
-		}
-	}
+	// Adobe - we allow
+	// if strings.Contains(host, "*") {
+	// 	sw.SetInvalid("Spec.VirtualHost.Fqdn %q cannot use wildcards", host)
+	// 	return
+	// }
 
 	var enforceTLS, passthrough bool
 	if tls := ir.Spec.VirtualHost.TLS; tls != nil {

--- a/internal/envoy/route_adobe.go
+++ b/internal/envoy/route_adobe.go
@@ -12,25 +12,6 @@ import (
 	"github.com/projectcontour/contour/internal/protobuf"
 )
 
-func PerFilterConfig(r *dag.Route) (conf map[string]*_struct.Struct) {
-	if r.PerFilterConfig == nil {
-		return
-	}
-
-	conf = make(map[string]*_struct.Struct)
-	var inInterface map[string]interface{}
-	inrec, _ := json.Marshal(r.PerFilterConfig)
-	json.Unmarshal(inrec, &inInterface)
-
-	for k, v := range inInterface {
-		s := new(_struct.Struct)
-		conf[k] = s
-
-		recurseIface(s, v)
-	}
-	return
-}
-
 func TypedPerFilterConfig(r *dag.Route) (conf map[string]*any.Any) {
 	if r.PerFilterConfig == nil {
 		return
@@ -38,7 +19,10 @@ func TypedPerFilterConfig(r *dag.Route) (conf map[string]*any.Any) {
 
 	conf = make(map[string]*any.Any)
 	var inInterface map[string]interface{}
-	inrec, _ := json.Marshal(r.PerFilterConfig)
+	inrec, err := json.Marshal(r.PerFilterConfig)
+	if err != nil {
+		return
+	}
 	json.Unmarshal(inrec, &inInterface)
 
 	for k, v := range inInterface {


### PR DESCRIPTION
- remove restriction on wildcard fqdn
- upgrade go to 1.14.9
- handle error when marshalling json(from pen-test findings)