### PR TITLE
Restore timeoutPolicy on IngressRoute

### DIFF
--- a/ADOBE_CHANGELOG.md
+++ b/ADOBE_CHANGELOG.md
@@ -16,6 +16,10 @@ v{C major}.{C minor}.{C fix}-{A major}.{A minor}.{A fix}-adobe
 
 # Log
 
+## _next release_
+
+- restore `timeoutPolicy`
+
 ## v1.5.1-2.12.1-adobe
 
 - indirectly fix Envoy issue with percent value of 0

--- a/adobe/adobe.go
+++ b/adobe/adobe.go
@@ -38,9 +38,6 @@ var ignoreTests = map[string]struct{}{
 	"multiple tls ingress with secrets should be sorted":            {}, // we group the filter chains together
 	"multiple httpproxies with fallback certificate":                {}, // we group the filter chains together
 	"invalid FQDN contains wildcard":                                {}, // allow wildcard fqdn
-	"insert ingressroute w/ invalid timeoutpolicy":                  {}, // we ignore timeoutpolicy
-	"insert ingressroute w/ valid timeoutpolicy":                    {}, // we ignore timeoutpolicy
-	"insert ingressroute w/ infinite timeoutpolicy":                 {}, // we ignore timeoutpolicy
 }
 
 func IgnoreFields() []cmp.Option {

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -1081,6 +1081,7 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 				Websocket:       route.EnableWebsockets,
 				HTTPSUpgrade:    routeEnforceTLS(enforceTLS, permitInsecure),
 				PrefixRewrite:   route.PrefixRewrite,
+				TimeoutPolicy:   ingressrouteTimeoutPolicy(route.TimeoutPolicy),
 				RetryPolicy:     retryPolicy(route.RetryPolicy),
 				HashPolicy:      route.HashPolicy,
 				PerFilterConfig: route.PerFilterConfig,


### PR DESCRIPTION
Restore the `timeoutPolicy` functionality for IngressRoute objects, though our `timeout` implementation takes precedence.